### PR TITLE
Update helper.ts

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -25,7 +25,7 @@ export function getBaseUrl(url?: string, prefix?: string): string {
 }
 
 export function normalizeFilename(fileName: string): string {
-    const illegalSymbols = [':', '#', '/', '\\', '|'];
+    const illegalSymbols = [':', '#', '/', '\\', '|', '?'];
     if (illegalSymbols.some((el) => fileName.contains(el))) {
         illegalSymbols.forEach((ilSymbol) => {
             fileName = fileName.replace(ilSymbol, '');


### PR DESCRIPTION
url: "https://windowsreport.com/epic-store-not-working/"
title: "Why is the Epic Games Launcher not loading properly? [Fixed]"

Note not created. This is maybe because in title of article is illegal character in obsidian file name "?" or "[]"
If i add '?' to illegal symbols the note is created successfull.