### PR TITLE
Add %date% variable for content in templates

### DIFF
--- a/src/parsers/Parser.ts
+++ b/src/parsers/Parser.ts
@@ -26,6 +26,6 @@ export abstract class Parser {
 
     protected getFormattedDateForFilename(): string {
         const date = new Date();
-        return moment(date).format('YYYY-MM-DD HH-mm-ss');
+        return moment(date).format(this.settings.dateTitleFmt);
     }
 }

--- a/src/parsers/Parser.ts
+++ b/src/parsers/Parser.ts
@@ -28,4 +28,9 @@ export abstract class Parser {
         const date = new Date();
         return moment(date).format(this.settings.dateTitleFmt);
     }
+
+    protected getFormattedDateForContent(): string {
+        const date = new Date();
+        return moment(date).format(this.settings.dateContentFmt);
+    }
 }

--- a/src/parsers/TextSnippetParser.ts
+++ b/src/parsers/TextSnippetParser.ts
@@ -16,7 +16,7 @@ class TextSnippetParser extends Parser {
         const fileName = `${this.getFormattedDateForFilename()}.md`;
         const content = this.settings.textSnippetNote
             .replace(/%content%/g, text)
-            .replace(/%date%/g, this.getFormattedDateForFilename());
+            .replace(/%date%/g, this.getFormattedDateForContent());
         return new Note(fileName, content);
     }
 }

--- a/src/parsers/TextSnippetParser.ts
+++ b/src/parsers/TextSnippetParser.ts
@@ -14,7 +14,9 @@ class TextSnippetParser extends Parser {
 
     async prepareNote(text: string): Promise<Note> {
         const fileName = `${this.getFormattedDateForFilename()}.md`;
-        const content = this.settings.textSnippetNote.replace(/%content%/g, text);
+        const content = this.settings.textSnippetNote
+            .replace(/%content%/g, text)
+            .replace(/%date%/g, this.getFormattedDateForFilename());
         return new Note(fileName, content);
     }
 }

--- a/src/parsers/TwitterParser.ts
+++ b/src/parsers/TwitterParser.ts
@@ -28,6 +28,7 @@ class TwitterParser extends Parser {
         const content = await parseHtmlContent(response.html);
 
         const processedContent = this.settings.twitterNote
+            .replace(/%date%/g, this.getFormattedDateForFilename())
             .replace(/%tweetAuthorName%/g, tweetAuthorName)
             .replace(/%tweetURL%/g, response.url)
             .replace(/%tweetContent%/g, content);

--- a/src/parsers/TwitterParser.ts
+++ b/src/parsers/TwitterParser.ts
@@ -28,7 +28,7 @@ class TwitterParser extends Parser {
         const content = await parseHtmlContent(response.html);
 
         const processedContent = this.settings.twitterNote
-            .replace(/%date%/g, this.getFormattedDateForFilename())
+            .replace(/%date%/g, this.getFormattedDateForContent())
             .replace(/%tweetAuthorName%/g, tweetAuthorName)
             .replace(/%tweetURL%/g, response.url)
             .replace(/%tweetContent%/g, content);

--- a/src/parsers/WebsiteParser.ts
+++ b/src/parsers/WebsiteParser.ts
@@ -51,6 +51,7 @@ class WebsiteParser extends Parser {
         }
 
         const processedContent = this.settings.parsableArticleNote
+            .replace(/%date%/g, this.getFormattedDateForFilename())
             .replace(/%articleTitle%/g, title)
             .replace(/%articleURL%/g, url)
             .replace(/%articleContent%/g, content);

--- a/src/parsers/WebsiteParser.ts
+++ b/src/parsers/WebsiteParser.ts
@@ -51,7 +51,7 @@ class WebsiteParser extends Parser {
         }
 
         const processedContent = this.settings.parsableArticleNote
-            .replace(/%date%/g, this.getFormattedDateForFilename())
+            .replace(/%date%/g, this.getFormattedDateForContent())
             .replace(/%articleTitle%/g, title)
             .replace(/%articleURL%/g, url)
             .replace(/%articleContent%/g, content);

--- a/src/parsers/YoutubeParser.ts
+++ b/src/parsers/YoutubeParser.ts
@@ -22,6 +22,7 @@ class YoutubeParser extends Parser {
         const videoPlayer = `<iframe width="560" height="315" src="https://www.youtube.com/embed/${videoId}" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>`;
 
         const content = this.settings.youtubeNote
+            .replace(/%date%/g, this.getFormattedDateForFilename())
             .replace(/%videoTitle%/g, videoTitle)
             .replace(/%videoURL%/g, url)
             .replace(/%videoId%/g, videoId)

--- a/src/parsers/YoutubeParser.ts
+++ b/src/parsers/YoutubeParser.ts
@@ -22,7 +22,7 @@ class YoutubeParser extends Parser {
         const videoPlayer = `<iframe width="560" height="315" src="https://www.youtube.com/embed/${videoId}" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>`;
 
         const content = this.settings.youtubeNote
-            .replace(/%date%/g, this.getFormattedDateForFilename())
+            .replace(/%date%/g, this.getFormattedDateForContent())
             .replace(/%videoTitle%/g, videoTitle)
             .replace(/%videoURL%/g, url)
             .replace(/%videoId%/g, videoId)

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -13,6 +13,7 @@ export interface ReadItLaterSettings {
     textSnippetNoteTitle: string;
     textSnippetNote: string;
     downloadImages: boolean;
+    dateTitleFmt: string;
 }
 
 export const DEFAULT_SETTINGS: ReadItLaterSettings = {
@@ -30,4 +31,5 @@ export const DEFAULT_SETTINGS: ReadItLaterSettings = {
     textSnippetNoteTitle: 'Notice %date%',
     textSnippetNote: `[[ReadItLater]] [[Textsnippet]]\n\n%content%`,
     downloadImages: true,
+    dateTitleFmt: 'YYYY-MM-DD HH-mm-ss',
 };

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -14,6 +14,7 @@ export interface ReadItLaterSettings {
     textSnippetNote: string;
     downloadImages: boolean;
     dateTitleFmt: string;
+    dateContentFmt: string;
 }
 
 export const DEFAULT_SETTINGS: ReadItLaterSettings = {
@@ -32,4 +33,5 @@ export const DEFAULT_SETTINGS: ReadItLaterSettings = {
     textSnippetNote: `[[ReadItLater]] [[Textsnippet]]\n\n%content%`,
     downloadImages: true,
     dateTitleFmt: 'YYYY-MM-DD HH-mm-ss',
+    dateContentFmt: 'YYYY-MM-DD',
 };

--- a/src/views/settings-tab.ts
+++ b/src/views/settings-tab.ts
@@ -74,6 +74,19 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
             );
 
         new Setting(containerEl)
+            .setName('Date format string')
+            .setDesc('Format of the %date% variable. NOTE: do not use symbols forbidden in file names.')
+            .addText((text) =>
+                text
+                    .setPlaceholder('Defaults to YYYY-MM-DD HH-mm-ss')
+                    .setValue(this.plugin.settings.dateTitleFmt || DEFAULT_SETTINGS.dateTitleFmt)
+                    .onChange(async (value) => {
+                        this.plugin.settings.dateTitleFmt = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
+
+        new Setting(containerEl)
             .setName('Youtube note template title')
             .setDesc('Available variables: %title%')
             .addText((text) =>

--- a/src/views/settings-tab.ts
+++ b/src/views/settings-tab.ts
@@ -86,6 +86,19 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
                     }),
             );
 
+    new Setting(containerEl)
+            .setName('Date format string in contents')
+            .setDesc('Format of the %date% variable for contents')
+            .addText((text) =>
+                text
+                    .setPlaceholder('Defaults to YYYY-MM-DD')
+                    .setValue(this.plugin.settings.dateContentFmt || DEFAULT_SETTINGS.dateContentFmt)
+                    .onChange(async (value) => {
+                        this.plugin.settings.dateContentFmt = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
+
         new Setting(containerEl)
             .setName('Youtube note template title')
             .setDesc('Available variables: %title%')

--- a/src/views/settings-tab.ts
+++ b/src/views/settings-tab.ts
@@ -88,7 +88,7 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
 
         new Setting(containerEl)
             .setName('Youtube note template')
-            .setDesc('Available variables: %videoTitle%, %videoURL%, %videoId%, %videoPlayer%')
+            .setDesc('Available variables: %date%, %videoTitle%, %videoURL%, %videoId%, %videoPlayer%')
             .addTextArea((textarea) => {
                 textarea
                     .setValue(this.plugin.settings.youtubeNote || DEFAULT_SETTINGS.youtubeNote)
@@ -114,7 +114,7 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
             );
         new Setting(containerEl)
             .setName('Twitter note template')
-            .setDesc('Available variables: %tweetAuthorName%, %tweetURL%, %tweetContent%')
+            .setDesc('Available variables: %date%, %tweetAuthorName%, %tweetURL%, %tweetContent%')
             .addTextArea((textarea) => {
                 textarea
                     .setValue(this.plugin.settings.twitterNote || DEFAULT_SETTINGS.twitterNote)
@@ -143,7 +143,7 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
 
         new Setting(containerEl)
             .setName('Parsable article note template')
-            .setDesc('Available variables: %articleTitle%, %articleURL%, %articleContent%')
+            .setDesc('Available variables: %date%, %articleTitle%, %articleURL%, %articleContent%')
             .addTextArea((textarea) => {
                 textarea
                     .setValue(this.plugin.settings.parsableArticleNote || DEFAULT_SETTINGS.parsableArticleNote)
@@ -173,7 +173,7 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
 
         new Setting(containerEl)
             .setName('Not parseable article note template')
-            .setDesc('Available variables: %articleURL%')
+            .setDesc('Available variables: %date%, %articleURL%')
             .addTextArea((textarea) => {
                 textarea
                     .setValue(this.plugin.settings.notParsableArticleNote || DEFAULT_SETTINGS.notParsableArticleNote)
@@ -200,7 +200,7 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
 
         new Setting(containerEl)
             .setName('Text snippet note template')
-            .setDesc('Available variables: %content%')
+            .setDesc('Available variables: %date%, %content%')
             .addTextArea((textarea) => {
                 textarea
                     .setValue(this.plugin.settings.textSnippetNote || DEFAULT_SETTINGS.textSnippetNote)


### PR DESCRIPTION
This PR provides a `%date%` variable to be used in all templates content.
Moreover, since the `%date%` used in titles might require different format than the one in content templates, this PR also add settings to configure both independently. 