### PR TITLE
Fix embeding YouTube videos for mobile apps

### DIFF
--- a/src/parsers/YoutubeParser.ts
+++ b/src/parsers/YoutubeParser.ts
@@ -15,7 +15,14 @@ class YoutubeParser extends Parser {
     }
 
     async prepareNote(url: string): Promise<Note> {
-        const response = await request({ method: 'GET', url });
+        const response = await request({
+            method: 'GET',
+            url,
+            headers: {
+                'user-agent':
+                    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36',
+            },
+        });
         const videoHTML = new DOMParser().parseFromString(response, 'text/html');
         const videoTitle = videoHTML.querySelector("[property~='og:title']").getAttribute('content');
         const videoId = this.PATTERN.exec(url)[4];


### PR DESCRIPTION
This PR provides fix for #43. 

It adds user-agent header with value of Chrome on Windows 10 to force loading of desktop YouTube site. Mobile site doesn't provide <meta> element with og:title attribute and content of <title> element is injected by Javascript. 