### PR TITLE
Fix replace illegal symbols in filename

### DIFF
--- a/src/helpers/fileutils.ts
+++ b/src/helpers/fileutils.ts
@@ -16,16 +16,7 @@ export function getBaseUrl(url: string, origin: string): string {
 }
 
 export function normalizeFilename(fileName: string): string {
-    const illegalSymbols = [':', '#', '/', '\\', '|', '?', '*', '<', '>', '"'];
-    if (illegalSymbols.some((el) => fileName.contains(el))) {
-        illegalSymbols.forEach((ilSymbol) => {
-            fileName = fileName.replace(ilSymbol, '');
-        });
-
-        return fileName;
-    } else {
-        return fileName;
-    }
+    return fileName.replace(/[\:\#\/\\\|\?\*\<\>\"]/g, '');
 }
 
 export function pathJoin(dir: string, subpath: string): string {


### PR DESCRIPTION
This PR provides fix for #46 and #34. Currently only the first occurrence of illegal symbol is replaced in filename. I refactored normalizeFilename function to use regex with global modifier and tested it on provided URLs in issues.