### PR TITLE
Use a folder for assets inside the assets folder

### DIFF
--- a/src/parsers/WebsiteParser.ts
+++ b/src/parsers/WebsiteParser.ts
@@ -61,7 +61,9 @@ class WebsiteParser extends Parser {
             .replace(/%title%/g, title)
             .replace(/%date%/g, this.getFormattedDateForFilename());
 
-        const assetsDir = `${this.settings.assetsDir}/${fileNameTemplate}/`;
+        const assetsDir = this.settings.downloadImagesInArticleDir
+            ? `${this.settings.assetsDir}/${fileNameTemplate}/`
+            : this.settings.assetsDir;
 
         if (this.settings.downloadImages && Platform.isDesktop) {
             content = await replaceImages(app, content, assetsDir);

--- a/src/parsers/WebsiteParser.ts
+++ b/src/parsers/WebsiteParser.ts
@@ -57,8 +57,14 @@ class WebsiteParser extends Parser {
         const title = article.title || 'No title';
         let content = await parseHtmlContent(article.content);
 
+        const fileNameTemplate = this.settings.parseableArticleNoteTitle
+            .replace(/%title%/g, title)
+            .replace(/%date%/g, this.getFormattedDateForFilename());
+
+        const assetsDir = `${this.settings.assetsDir}/${fileNameTemplate}/`;
+
         if (this.settings.downloadImages && Platform.isDesktop) {
-            content = await replaceImages(app, content, this.settings.assetsDir);
+            content = await replaceImages(app, content, assetsDir);
         }
 
         const processedContent = this.settings.parsableArticleNote
@@ -66,10 +72,6 @@ class WebsiteParser extends Parser {
             .replace(/%articleTitle%/g, title)
             .replace(/%articleURL%/g, url)
             .replace(/%articleContent%/g, content);
-
-        const fileNameTemplate = this.settings.parseableArticleNoteTitle
-            .replace(/%title%/g, title)
-            .replace(/%date%/g, this.getFormattedDateForFilename());
 
         const fileName = `${fileNameTemplate}.md`;
         return new Note(fileName, processedContent);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -15,6 +15,7 @@ export interface ReadItLaterSettings {
     textSnippetNoteTitle: string;
     textSnippetNote: string;
     downloadImages: boolean;
+    downloadImagesInArticleDir: boolean;
     dateTitleFmt: string;
     dateContentFmt: string;
 }
@@ -36,6 +37,7 @@ export const DEFAULT_SETTINGS: ReadItLaterSettings = {
     textSnippetNoteTitle: 'Notice %date%',
     textSnippetNote: `[[ReadItLater]] [[Textsnippet]]\n\n%content%`,
     downloadImages: true,
+    downloadImagesInArticleDir: false,
     dateTitleFmt: 'YYYY-MM-DD HH-mm-ss',
     dateContentFmt: 'YYYY-MM-DD',
 };

--- a/src/views/settings-tab.ts
+++ b/src/views/settings-tab.ts
@@ -53,6 +53,21 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
                     .onChange(async (value) => {
                         this.plugin.settings.downloadImages = value;
                         assetDirSetting.setDisabled(!value);
+                        imagesInArticleDirSettings.setDisabled(!value);
+                        await this.plugin.saveSettings();
+                    }),
+            );
+
+        const imagesInArticleDirSettings = new Setting(containerEl)
+            .setName('Download imagesPer Article dir insied assets')
+            .setDesc(
+                'If this is true, the images of an article are stored in their own folder.',
+            )
+            .addToggle((toggle) =>
+                toggle
+                    .setValue(this.plugin.settings.downloadImagesInArticleDir || DEFAULT_SETTINGS.downloadImagesInArticleDir)
+                    .onChange(async (value) => {
+                        this.plugin.settings.downloadImagesInArticleDir = value;
                         await this.plugin.saveSettings();
                     }),
             );
@@ -216,7 +231,7 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
                     .setPlaceholder(`Defaults to 'Article %date%'`)
                     .setValue(
                         this.plugin.settings.notParseableArticleNoteTitle ||
-                            DEFAULT_SETTINGS.notParseableArticleNoteTitle,
+                        DEFAULT_SETTINGS.notParseableArticleNoteTitle,
                     )
                     .onChange(async (value) => {
                         this.plugin.settings.notParseableArticleNoteTitle = value;


### PR DESCRIPTION
This commit changes the behavior from  downloading images in assets to downloading in `assets/{note name}/` so that when you want to delete a note or move it you know where the assets are.

It partially solves #50 as it doen't give the suggested solution but it gives a way to identify per note assets 😁