### PR TITLE
Fix for #60 Unable to save non-parsable webpages

### DIFF
--- a/src/parsers/WebsiteParser.ts
+++ b/src/parsers/WebsiteParser.ts
@@ -84,10 +84,11 @@ class WebsiteParser extends Parser {
 
         const content = this.settings.notParsableArticleNote.replace('%articleURL%', url);
 
-        const fileNameTemplate = this.settings.notParsableArticleNote.replace(
+        const fileNameTemplate = this.settings.notParseableArticleNoteTitle.replace(
             /%date%/g,
             this.getFormattedDateForFilename(),
         );
+
         const fileName = `${fileNameTemplate}.md`;
         return new Note(fileName, content);
     }


### PR DESCRIPTION
Fixes #60 Unable to save non-parsable webpages.

Seems there was a typo in `WebsiteParsesr` `notParsableArticle/1`. The new note's filename was being set to `notParsableArticleNote` instead of `notParseableArticleNoteTitle`.