### PR TITLE
feat: Add parser for Stack Exchange sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
     - [Vimeo](#vimeo)
     - [Bilibili](#bilibili)
     - [Twitter](#twitter)
+    - [Stack Exchange](#stack-exchange)
     - [Mastodon](#mastodon)
     - [Website URL](#website-url)
     - [Text Snippet](#text-snippet)
@@ -95,6 +96,37 @@ Will be converted to markdown note with data from [Twitter Publish API](https://
 | %date%                    | Current date in format from plugin settings |
 | %tweetURL%                | Twitter Publish API                         |
 | %tweetContent%            | Twitter Publish API                         |
+
+### Stack Exchange
+
+Will be converted to markdown with parsed question and answers from DOM.
+
+| Title template variable | Retrieved from                              |
+| ----------------------- | ------------------------------------------- |
+| %title%                 | HTML element                                |
+| %date%                  | Current date in format from plugin settings |
+
+***Note template variables***
+
+| Content template variable | Retrieved from                              |
+| ------------------------- | ------------------------------------------- |
+| %date%                    | Current date in format from plugin settings |
+| %questionTitle%           | HTML element                                |
+| %questionURL%             | HTML element                                |
+| %questionContent%         | HTML element                                |
+| %authorName%              | HTML element                                |
+| %authorProfileURL         | HTML element                                |
+| %topAnswer%               | HTML element                                |
+| %answers%                 | HTML elements                               |
+
+***Partial answer template variables***
+
+| Content template variable | Retrieved from                              |
+| ------------------------- | ------------------------------------------- |
+| %date%                    | Current date in format from plugin settings |
+| %answerContent%           | HTML element                                |
+| %authorName%              | HTML element                                |
+| %authorProfileURL         | HTML element                                |
 
 ### Mastodon
 

--- a/src/helpers/checkAndCreateFolder.ts
+++ b/src/helpers/checkAndCreateFolder.ts
@@ -1,4 +1,4 @@
-import { normalizePath, TFolder, Vault } from 'obsidian';
+import { TFolder, Vault, normalizePath } from 'obsidian';
 
 /**
  * Open or create a folderpath if it does not exist

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { addIcon, normalizePath, Notice, Plugin } from 'obsidian';
+import { Notice, Plugin, addIcon, normalizePath } from 'obsidian';
 import { checkAndCreateFolder, normalizeFilename } from './helpers';
 import { DEFAULT_SETTINGS, ReadItLaterSettings } from './settings';
 import { ReadItLaterSettingsTab } from './views/settings-tab';
@@ -7,6 +7,7 @@ import YoutubeParser from './parsers/YoutubeParser';
 import VimeoParser from './parsers/VimeoParser';
 import BilibiliParser from './parsers/BilibiliParser';
 import TwitterParser from './parsers/TwitterParser';
+import StackExchangeParser from './parsers/StackExchangeParser';
 import WebsiteParser from './parsers/WebsiteParser';
 import TextSnippetParser from './parsers/TextSnippetParser';
 import MastodonParser from './parsers/MastodonParser';
@@ -23,6 +24,7 @@ export default class ReadItLaterPlugin extends Plugin {
             new VimeoParser(this.app, this.settings),
             new BilibiliParser(this.app, this.settings),
             new TwitterParser(this.app, this.settings),
+            new StackExchangeParser(this.app, this.settings),
             new MastodonParser(this.app, this.settings),
             new WebsiteParser(this.app, this.settings),
             new TextSnippetParser(this.app, this.settings),

--- a/src/parsers/StackExchangeParser.ts
+++ b/src/parsers/StackExchangeParser.ts
@@ -1,0 +1,141 @@
+import { Parser } from './Parser';
+import { Note } from './Note';
+import { App, Platform, request } from 'obsidian';
+import { normalizeFilename, replaceImages } from '../helpers';
+import { ReadItLaterSettings } from '../settings';
+import * as DOMPurify from 'isomorphic-dompurify';
+import { parseHtmlContent } from './parsehtml';
+
+interface StackExchangeQuestion {
+    title: string;
+    content: string;
+    url: string;
+    topAnswer: StackExchangeAnswer;
+    answers: Array<StackExchangeAnswer>;
+    author: StackExchangeUser;
+}
+
+interface StackExchangeAnswer {
+    content: string;
+    author: StackExchangeUser;
+}
+
+interface StackExchangeUser {
+    name: string;
+    profile: string;
+}
+
+class StackExchangeParser extends Parser {
+    private PATTERN =
+        /(https:\/\/|http:\/\/)(stackoverflow\.com|serverfault\.com|superuser\.com|askubuntu\.com|stackapps\.com|.*\.stackexchange\.com)\/(q|a|questions)\/(\d+)/;
+
+    constructor(app: App, settings: ReadItLaterSettings) {
+        super(app, settings);
+    }
+
+    test(clipboardContent: string): boolean {
+        return this.isValidUrl(clipboardContent) && this.PATTERN.test(clipboardContent);
+    }
+
+    async prepareNote(clipboardContent: string): Promise<Note> {
+        const response = await request({ method: 'GET', url: clipboardContent });
+        const document = new DOMParser().parseFromString(response, 'text/html');
+        const question = await this.parseDocument(document);
+
+        const fileNameTemplate = this.settings.stackExchangeNoteTitle
+            .replace(/%title%/g, question.title)
+            .replace(/%date%/g, this.getFormattedDateForFilename());
+
+        const topAnswer = question.topAnswer
+            ? this.settings.stackExchangeAnswer
+                  .replace(/%answerContent%/g, question.topAnswer.content)
+                  .replace(/%authorName%/g, question.topAnswer.author.name)
+                  .replace(/%authorProfileURL%/g, question.topAnswer.author.profile)
+            : '';
+
+        let answers = '';
+        for (let i = 0; i < question.answers.length; i++) {
+            const answer = this.settings.stackExchangeAnswer
+                .replace(/%answerContent%/g, question.answers[i].content)
+                .replace(/%authorName%/g, question.answers[i].author.name)
+                .replace(/%authorProfileURL%/g, question.answers[i].author.profile);
+            answers = answers.concat('\n\n***\n\n', answer);
+        }
+
+        let content = this.settings.stackExchangeNote
+            .replace(/%date%/g, this.getFormattedDateForContent())
+            .replace(/%questionTitle%/g, question.title)
+            .replace(/%questionURL%/g, question.url)
+            .replace(/%questionContent%/g, question.content)
+            .replace(/%authorName%/g, question.author.name)
+            .replace(/%authorProfileURL%/g, question.author.profile)
+            .replace(/%topAnswer%/g, topAnswer)
+            .replace(/%answers%/g, answers.trim());
+
+        const assetsDir = this.settings.downloadStackExchangeAssetsInDir
+            ? `${this.settings.assetsDir}/${normalizeFilename(fileNameTemplate)}/`
+            : this.settings.assetsDir;
+
+        if (this.settings.downloadStackExchangeAssets && Platform.isDesktop) {
+            content = await replaceImages(app, content, assetsDir);
+        }
+
+        const fileName = `${fileNameTemplate}.md`;
+        return new Note(fileName, content);
+    }
+
+    private async parseDocument(document: Document): Promise<StackExchangeQuestion> {
+        let questionURL;
+        try {
+            questionURL = new URL(
+                document.querySelector('link[rel="canonical"]')?.getAttribute('href') ??
+                    document.querySelector('meta[property="og:url"]')?.getAttribute('content'),
+            );
+        } catch (e) {
+            questionURL = null;
+        }
+
+        const author = document.querySelector('#question [itemprop="author"]');
+
+        const answers: Array<StackExchangeAnswer> = [];
+        for (const el of document.querySelectorAll('.answer')) {
+            const answerAuthor = el.querySelector('[itemprop="author"]');
+
+            answers.push({
+                content: await parseHtmlContent(DOMPurify.sanitize(el.querySelector('[itemprop="text"]') ?? '')),
+                author: {
+                    name: answerAuthor?.querySelector('[itemprop="name"]')?.textContent ?? '',
+                    profile:
+                        answerAuthor instanceof Element && questionURL instanceof URL
+                            ? String.prototype.concat(
+                                  questionURL.origin,
+                                  answerAuthor.querySelector('a')?.getAttribute('href') ?? '',
+                              )
+                            : '',
+                },
+            });
+        }
+
+        return {
+            title: document.querySelector('#question-header [itemprop="name"]')?.textContent ?? '',
+            content: await parseHtmlContent(
+                DOMPurify.sanitize(document.querySelector('#question [itemprop="text"]') ?? ''),
+            ),
+            url: questionURL?.href ?? '',
+            topAnswer: answers.slice(0, 1).shift(),
+            answers: answers.slice(1),
+            author: {
+                name: author?.querySelector('[itemprop="name"]')?.textContent ?? '',
+                profile:
+                    author instanceof Element && questionURL instanceof URL
+                        ? String.prototype.concat(
+                              questionURL.origin,
+                              author.querySelector('a')?.getAttribute('href') ?? '',
+                          )
+                        : '',
+            },
+        };
+    }
+}
+
+export default StackExchangeParser;

--- a/src/parsers/WebsiteParser.ts
+++ b/src/parsers/WebsiteParser.ts
@@ -2,7 +2,7 @@ import { Parser } from './Parser';
 import { Note } from './Note';
 import { App, Notice, Platform, request } from 'obsidian';
 import { getBaseUrl, normalizeFilename, replaceImages } from '../helpers';
-import { isProbablyReaderable, Readability } from '@mozilla/readability';
+import { Readability, isProbablyReaderable } from '@mozilla/readability';
 import { ReadItLaterSettings } from '../settings';
 import * as DOMPurify from 'isomorphic-dompurify';
 import { parseHtmlContent } from './parsehtml';

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -64,7 +64,7 @@ export const DEFAULT_SETTINGS: ReadItLaterSettings = {
     stackExchangeNoteTitle: '%title%',
     stackExchangeNote:
         '[[ReadItLater]] [[StackExchange]]\n\n# [%questionTitle%](%questionURL%)\n\nAuthor: [%authorName%](%authorProfileURL%)\n\n%questionContent%\n\n***\n\n%topAnswer%\n\n%answers%',
-    stackExchangeAnswer: 'Author: [%authorName%](%authorProfileURL%)\n\n%answerContent%',
+    stackExchangeAnswer: 'Answered by: [%authorName%](%authorProfileURL%)\n\n%answerContent%',
     downloadStackExchangeAssets: true,
-    downloadStackExchangeAssetsInDir: true,
+    downloadStackExchangeAssetsInDir: false,
 };

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -26,6 +26,11 @@ export interface ReadItLaterSettings {
     downloadMastodonMediaAttachmentsInDir: boolean;
     saveMastodonReplies: boolean;
     mastodonReply: string;
+    stackExchangeNoteTitle: string;
+    stackExchangeNote: string;
+    stackExchangeAnswer: string;
+    downloadStackExchangeAssets: boolean;
+    downloadStackExchangeAssetsInDir: boolean;
 }
 
 export const DEFAULT_SETTINGS: ReadItLaterSettings = {
@@ -33,21 +38,21 @@ export const DEFAULT_SETTINGS: ReadItLaterSettings = {
     assetsDir: 'ReadItLater Inbox/assets',
     openNewNote: false,
     youtubeNoteTitle: 'Youtube - %title%',
-    youtubeNote: `[[ReadItLater]] [[Youtube]]\n\n# [%videoTitle%](%videoURL%)\n\n%videoPlayer%`,
+    youtubeNote: '[[ReadItLater]] [[Youtube]]\n\n# [%videoTitle%](%videoURL%)\n\n%videoPlayer%',
     vimeoNoteTitle: 'Vimeo - %title%',
-    vimeoNote: `[[ReadItLater]] [[Vimeo]]\n\n# [%videoTitle%](%videoURL%)\n\n%videoPlayer%`,
+    vimeoNote: '[[ReadItLater]] [[Vimeo]]\n\n# [%videoTitle%](%videoURL%)\n\n%videoPlayer%',
     bilibiliNoteTitle: 'Bilibili - %title%',
-    bilibiliNote: `[[ReadItLater]] [[Bilibili]]\n\n# [%videoTitle%](%videoURL%)\n\n%videoPlayer%`,
+    bilibiliNote: '[[ReadItLater]] [[Bilibili]]\n\n# [%videoTitle%](%videoURL%)\n\n%videoPlayer%',
     twitterNoteTitle: 'Tweet from %tweetAuthorName% (%date%)',
-    twitterNote: `[[ReadItLater]] [[Tweet]]\n\n# [%tweetAuthorName%](%tweetURL%)\n\n%tweetContent%`,
+    twitterNote: '[[ReadItLater]] [[Tweet]]\n\n# [%tweetAuthorName%](%tweetURL%)\n\n%tweetContent%',
     parseableArticleNoteTitle: '%title%',
-    parsableArticleNote: `[[ReadItLater]] [[Article]]\n\n# [%articleTitle%](%articleURL%)\n\n%articleContent%`,
+    parsableArticleNote: '[[ReadItLater]] [[Article]]\n\n# [%articleTitle%](%articleURL%)\n\n%articleContent%',
     notParseableArticleNoteTitle: 'Article %date%',
-    notParsableArticleNote: `[[ReadItLater]] [[Article]]\n\n[%articleURL%](%articleURL%)`,
+    notParsableArticleNote: '[[ReadItLater]] [[Article]]\n\n[%articleURL%](%articleURL%)',
     textSnippetNoteTitle: 'Note %date%',
-    textSnippetNote: `[[ReadItLater]] [[Textsnippet]]\n\n%content%`,
+    textSnippetNote: '[[ReadItLater]] [[Textsnippet]]\n\n%content%',
     mastodonNoteTitle: 'Toot from %tootAuthorName% (%date%)',
-    mastodonNote: `[[ReadItLater]] [[Toot]]\n\n# [%tootAuthorName%](%tootURL%)\n\n> %tootContent%`,
+    mastodonNote: '[[ReadItLater]] [[Toot]]\n\n# [%tootAuthorName%](%tootURL%)\n\n> %tootContent%',
     downloadImages: true,
     downloadImagesInArticleDir: false,
     dateTitleFmt: 'YYYY-MM-DD HH-mm-ss',
@@ -55,5 +60,11 @@ export const DEFAULT_SETTINGS: ReadItLaterSettings = {
     downloadMastodonMediaAttachments: true,
     downloadMastodonMediaAttachmentsInDir: false,
     saveMastodonReplies: false,
-    mastodonReply: `[%tootAuthorName%](%tootURL%)\n\n> %tootContent%`,
+    mastodonReply: '[%tootAuthorName%](%tootURL%)\n\n> %tootContent%',
+    stackExchangeNoteTitle: '%title%',
+    stackExchangeNote:
+        '[[ReadItLater]] [[StackExchange]]\n\n# [%questionTitle%](%questionURL%)\n\nAuthor: [%authorName%](%authorProfileURL%)\n\n%questionContent%\n\n***\n\n%topAnswer%\n\n%answers%',
+    stackExchangeAnswer: 'Author: [%authorName%](%authorProfileURL%)\n\n%answerContent%',
+    downloadStackExchangeAssets: true,
+    downloadStackExchangeAssetsInDir: true,
 };

--- a/src/views/settings-tab.ts
+++ b/src/views/settings-tab.ts
@@ -204,6 +204,88 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
                 textarea.inputEl.cols = 25;
             });
 
+        containerEl.createEl('h2', {text: 'Stack Exchange'});
+
+        new Setting(containerEl)
+            .setName('Stack Exchange note title template')
+            .setDesc('Available variables: %title%, %date%')
+            .addText((text) =>
+                text
+                    .setPlaceholder('Defaults to %title%')
+                    .setValue(this.plugin.settings.stackExchangeNoteTitle || DEFAULT_SETTINGS.stackExchangeNoteTitle)
+                    .onChange(async (value) => {
+                        this.plugin.settings.stackExchangeNoteTitle = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
+
+        new Setting(containerEl)
+            .setName('Stack Exchange question note template')
+            .setDesc('Available variables: %date%, %questionTitle%, %questionURL%, %authorName%, %authorProfileURL%, %questionContent%, %topAnswer%, %answers%')
+            .addTextArea((textarea) => {
+                textarea
+                    .setValue(this.plugin.settings.stackExchangeNote || DEFAULT_SETTINGS.stackExchangeNote)
+                    .onChange(async (value) => {
+                        this.plugin.settings.stackExchangeNote = value;
+                        await this.plugin.saveSettings();
+                    });
+                textarea.inputEl.rows = 10;
+                textarea.inputEl.cols = 25;
+            });
+
+        new Setting(containerEl)
+            .setName('Stack Exchange answer template')
+            .setDesc('Available variables: %date%, %answerContent%, %authorName%, %authorProfileURL%')
+            .addTextArea((textarea) => {
+                textarea
+                    .setValue(this.plugin.settings.stackExchangeAnswer || DEFAULT_SETTINGS.stackExchangeAnswer)
+                    .onChange(async (value) => {
+                        this.plugin.settings.stackExchangeAnswer = value;
+                        await this.plugin.saveSettings();
+                    });
+                textarea.inputEl.rows = 10;
+                textarea.inputEl.cols = 25;
+            });
+
+        new Setting(containerEl)
+            .setName('Download media attachments')
+            .setDesc(
+                'If enabled, media attachments are downloaded to the assets folder (only Desktop App feature)',
+            )
+            .addToggle((toggle) =>
+                toggle
+                    .setValue(
+                        Object.prototype.hasOwnProperty.call(this.plugin.settings, 'downloadStackExchangeAssets')
+                            ? this.plugin.settings.downloadStackExchangeAssets
+                            : DEFAULT_SETTINGS.downloadStackExchangeAssets,
+                    )
+                    .onChange(async (value) => {
+                        this.plugin.settings.downloadStackExchangeAssets = value;
+                        stackExchangeMediaAttachmentsInDirSetting.setDisabled(!value);
+                        await this.plugin.saveSettings();
+                    }),
+            );
+
+        const stackExchangeMediaAttachmentsInDirSetting = new Setting(containerEl)
+            .setName('Download media attachments to folder')
+            .setDesc('If enabled, the media attachments are stored in their own folder.')
+            .addToggle((toggle) =>
+                toggle
+                    .setValue(
+                        Object.prototype.hasOwnProperty.call(
+                            this.plugin.settings,
+                            'downloadStackExchangeAssetsInDir',
+                        )
+                            ? this.plugin.settings.downloadStackExchangeAssetsInDir
+                            : DEFAULT_SETTINGS.downloadStackExchangeAssetsInDir,
+                    )
+                    .onChange(async (value) => {
+                        this.plugin.settings.downloadStackExchangeAssetsInDir = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
+
+
         containerEl.createEl('h2', { text: 'Mastodon' });
 
         new Setting(containerEl)

--- a/src/views/settings-tab.ts
+++ b/src/views/settings-tab.ts
@@ -374,7 +374,7 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
             .setDesc('Available variables: %date%')
             .addText((text) =>
                 text
-                    .setPlaceholder(`Defaults to 'Article %date%'`)
+                    .setPlaceholder("Defaults to 'Article %date%'")
                     .setValue(
                         this.plugin.settings.notParseableArticleNoteTitle ||
                             DEFAULT_SETTINGS.notParseableArticleNoteTitle,
@@ -406,7 +406,7 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
             .setDesc('Available variables: %date%')
             .addText((text) =>
                 text
-                    .setPlaceholder(`Defaults to 'Note %date%'`)
+                    .setPlaceholder("Defaults to 'Note %date%'")
                     .setValue(this.plugin.settings.textSnippetNoteTitle || DEFAULT_SETTINGS.textSnippetNoteTitle)
                     .onChange(async (value) => {
                         this.plugin.settings.textSnippetNoteTitle = value;

--- a/src/views/settings-tab.ts
+++ b/src/views/settings-tab.ts
@@ -204,7 +204,7 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
                 textarea.inputEl.cols = 25;
             });
 
-        containerEl.createEl('h2', {text: 'Stack Exchange'});
+        containerEl.createEl('h2', { text: 'Stack Exchange' });
 
         new Setting(containerEl)
             .setName('Stack Exchange note title template')
@@ -221,7 +221,9 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
 
         new Setting(containerEl)
             .setName('Stack Exchange question note template')
-            .setDesc('Available variables: %date%, %questionTitle%, %questionURL%, %authorName%, %authorProfileURL%, %questionContent%, %topAnswer%, %answers%')
+            .setDesc(
+                'Available variables: %date%, %questionTitle%, %questionURL%, %authorName%, %authorProfileURL%, %questionContent%, %topAnswer%, %answers%',
+            )
             .addTextArea((textarea) => {
                 textarea
                     .setValue(this.plugin.settings.stackExchangeNote || DEFAULT_SETTINGS.stackExchangeNote)
@@ -249,9 +251,7 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
 
         new Setting(containerEl)
             .setName('Download media attachments')
-            .setDesc(
-                'If enabled, media attachments are downloaded to the assets folder (only Desktop App feature)',
-            )
+            .setDesc('If enabled, media attachments are downloaded to the assets folder (only Desktop App feature)')
             .addToggle((toggle) =>
                 toggle
                     .setValue(
@@ -272,10 +272,7 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
             .addToggle((toggle) =>
                 toggle
                     .setValue(
-                        Object.prototype.hasOwnProperty.call(
-                            this.plugin.settings,
-                            'downloadStackExchangeAssetsInDir',
-                        )
+                        Object.prototype.hasOwnProperty.call(this.plugin.settings, 'downloadStackExchangeAssetsInDir')
                             ? this.plugin.settings.downloadStackExchangeAssetsInDir
                             : DEFAULT_SETTINGS.downloadStackExchangeAssetsInDir,
                     )
@@ -284,7 +281,6 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
                         await this.plugin.saveSettings();
                     }),
             );
-
 
         containerEl.createEl('h2', { text: 'Mastodon' });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,9 +12,11 @@
     "allowSyntheticDefaultImports": true,
     "lib": [
       "dom",
+      "dom.iterable",
       "es5",
-      "scripthost",
-      "es2015"
+      "es6",
+      "es7",
+      "scripthost"
     ]
   },
   "include": [


### PR DESCRIPTION
# Description

New parser for Stack Exchange sites.

## Motivation and Context

WebsiteParser cannot process whole Stack Exchange page. This new parser adds support for saving whole page and with own template and variables. 

## How has this been tested?

Tested on multiple sites from Stack Exchange such as:

- https://askubuntu.com/questions/1452299/im-getting-the-error-the-following-security-updates-require-ubuntu-pro-with-e
- https://stackoverflow.com/questions/67230981/can-i-enable-exceptions-on-warnings-in-production
- https://stackoverflow.com/questions/69599286/how-do-you-make-text-flow-below-an-image

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content)

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `npm run lint`.
- [x] My change requires an update of README.md
- [x] I have updated the README.md
