### PR TITLE
fix: Add comma to excluded characters list of Youtube API tags

### DIFF
--- a/src/parsers/YoutubeParser.ts
+++ b/src/parsers/YoutubeParser.ts
@@ -106,7 +106,7 @@ class YoutubeParser extends Parser {
                 duration: toSeconds(duration),
                 durationFormatted: this.formatDuration(duration),
                 viewsCount: video.statistics.viewCount,
-                tags: video.snippet.tags.map((tag) => tag.replace(/[\s:\-_]/g, '').replace(/^/, '#')),
+                tags: video.snippet.tags.map((tag) => tag.replace(/[\s:\-_.]/g, '').replace(/^/, '#')),
                 channel: {
                     id: channel.id,
                     url: `https://www.youtube.com/channel/${channel.id}`,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Add comma to excluded characters list of YouTube API tags.

## Motivation and Context

Ensure valid format of Obsidian tags.

## How has this been tested?

https://www.youtube.com/watch?v=3zTCjT_5IFw

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content)

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `npm run lint`.
- [ ] My change requires an update of README.md
- [ ] I have updated the README.md
