### PR TITLE
Correct a typo in Settings UI

### DIFF
--- a/src/views/settings-tab.ts
+++ b/src/views/settings-tab.ts
@@ -20,7 +20,7 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
         new Setting(containerEl)
             .setName('Inbox dir')
             .setDesc(
-                'Enter valid folder name. For nested folders use this format: Folder A/Folder B. If no folder is enetred, new note will be created in vault root.',
+                'Enter valid folder name. For nested folders use this format: Folder A/Folder B. If no folder is entered, new note will be created in vault root.',
             )
             .addText((text) =>
                 text
@@ -35,7 +35,7 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
         new Setting(containerEl)
             .setName('Assets dir')
             .setDesc(
-                'Enter valid folder name. For nested folders use this format: Folder A/Folder B. If no folder is enetred, new note will be created in vault root.',
+                'Enter valid folder name. For nested folders use this format: Folder A/Folder B. If no folder is entered, new note will be created in vault root.',
             )
             .addText((text) =>
                 text


### PR DESCRIPTION
In the settings UI, the word "entered" appears twice as "enetred".  This PR replaces that typo with the correct spelling in both cases.