### PR TITLE
Fix/youtube video without tags

### DIFF
--- a/src/parsers/YoutubeParser.ts
+++ b/src/parsers/YoutubeParser.ts
@@ -106,7 +106,7 @@ class YoutubeParser extends Parser {
                 duration: toSeconds(duration),
                 durationFormatted: this.formatDuration(duration),
                 viewsCount: video.statistics.viewCount,
-                tags: video.snippet.tags.map((tag) => tag.replace(/[\s:\-_.]/g, '').replace(/^/, '#')),
+                tags: video.hasOwnProperty('tags') ? video.snippet.tags.map((tag) => tag.replace(/[\s:\-_.]/g, '').replace(/^/, '#')) : [],
                 channel: {
                     id: channel.id,
                     url: `https://www.youtube.com/channel/${channel.id}`,

--- a/src/parsers/YoutubeParser.ts
+++ b/src/parsers/YoutubeParser.ts
@@ -106,7 +106,9 @@ class YoutubeParser extends Parser {
                 duration: toSeconds(duration),
                 durationFormatted: this.formatDuration(duration),
                 viewsCount: video.statistics.viewCount,
-                tags: video.hasOwnProperty('tags') ? video.snippet.tags.map((tag) => tag.replace(/[\s:\-_.]/g, '').replace(/^/, '#')) : [],
+                tags: Object.prototype.hasOwnProperty.call(video, 'tags')
+                    ? video.snippet.tags.map((tag) => tag.replace(/[\s:\-_.]/g, '').replace(/^/, '#'))
+                    : [],
                 channel: {
                     id: channel.id,
                     url: `https://www.youtube.com/channel/${channel.id}`,


### PR DESCRIPTION
# Description

Added check if Youtube API v3 response includes tags. If not, empty array is provided.

## Motivation and Context

User reported an issue with saving video without tags.

## How has this been tested?

Tested on provided link https://www.youtube.com/watch?v=-L32tZMbSZI but also on random one https://www.youtube.com/watch?v=Ow_qI_F2ZJI&pp=ygUGdGhyb25l

## Types of changes

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content)

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

- [x] My code follows the code style of this project and passes `npm run lint`.
- [ ] My change requires an update of README.md
- [ ] I have updated the README.md
