### PR TITLE
fix: YouTube regex to match only video ID

### DIFF
--- a/src/parsers/YoutubeParser.ts
+++ b/src/parsers/YoutubeParser.ts
@@ -26,7 +26,7 @@ interface YoutubeChannel {
 }
 
 class YoutubeParser extends Parser {
-    private PATTERN = /(youtube.com|youtu.be)\/(watch|shorts)?(\?v=|\/)?(\S+)?/;
+    private PATTERN = /(youtube.com|youtu.be)\/(watch|shorts)?(\?v=|\/)?([^&#?]*)/;
 
     constructor(app: App, settings: ReadItLaterSettings) {
         super(app, settings);


### PR DESCRIPTION
# Description

Fix for YouTube regex to match only video ID.

## Motivation and Context

Recently YouTube added additional query parameter "pp" to links in search. Although it currently doesn't affect parsing either API response or HTML DOM it'll be safe to work with valid values.

## How has this been tested?

Various YouTube links:
- https://www.youtube.com/watch?v=Ow_qI_F2ZJI&pp=ygUGdGhyb25l
- https://youtu.be/Ow_qI_F2ZJI
- https://youtube.com/shorts/gSgiEQcTzHM?feature=share

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content)

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `npm run lint`.
- [ ] My change requires an update of README.md
- [ ] I have updated the README.md
