### PR TITLE
feat: Add settings to customize embed player size

### DIFF
--- a/src/parsers/BilibiliParser.ts
+++ b/src/parsers/BilibiliParser.ts
@@ -26,7 +26,7 @@ class BilibiliParser extends Parser {
         const videoHTML = new DOMParser().parseFromString(response, 'text/html');
         const videoTitle = videoHTML.querySelector("[property~='og:title']").getAttribute('content');
         const videoId = this.PATTERN.exec(url)[3];
-        const videoPlayer = `<iframe width="560" height="315" src="https://player.bilibili.com/player.html?bvid=${videoId}" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true"></iframe>`;
+        const videoPlayer = `<iframe width="${this.settings.bilibiliEmbedWidth}" height="${this.settings.bilibiliEmbedHeight}" src="https://player.bilibili.com/player.html?bvid=${videoId}" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true"></iframe>`;
 
         const content = this.settings.bilibiliNote
             .replace(/%date%/g, this.getFormattedDateForContent())

--- a/src/parsers/TikTokParser.ts
+++ b/src/parsers/TikTokParser.ts
@@ -64,7 +64,7 @@ class TikTokParser extends Parser {
             id: videoRegexExec[4],
             url: videoHTML.querySelector('meta[property="og:url"]')?.getAttribute('content') ?? url,
             description: videoHTML.querySelector('meta[property="og:description"]')?.getAttribute('content') ?? '',
-            player: `<iframe width="325" height="760" src="https://www.tiktok.com/embed/v2/${videoRegexExec[4]}"></iframe>`,
+            player: `<iframe width="${this.settings.tikTokEmbedWidth}" height="${this.settings.tikTokEmbedHeight}" src="https://www.tiktok.com/embed/v2/${videoRegexExec[4]}"></iframe>`,
             author: {
                 name: videoRegexExec[2],
                 url: `https://www.tiktok.com/${videoRegexExec[2]}`,

--- a/src/parsers/VimeoParser.ts
+++ b/src/parsers/VimeoParser.ts
@@ -83,7 +83,7 @@ class VimeoParser extends Parser {
             id: videoIdRegexExec.length === 3 ? videoIdRegexExec[2] : '',
             url: videoSchema?.url ?? '',
             title: videoSchema?.name ?? '',
-            player: `<iframe width="560" height="315" src="${videoSchema?.embedUrl}" title="Vimeo video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>`,
+            player: `<iframe width="${this.settings.vimeoEmbedWidth}" height="${this.settings.vimeoEmbedHeight}" src="${videoSchema?.embedUrl}" title="Vimeo video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>`,
             channel: {
                 name: videoSchema?.author?.name ?? '',
                 url: videoSchema?.author?.url ?? '',

--- a/src/parsers/YoutubeParser.ts
+++ b/src/parsers/YoutubeParser.ts
@@ -94,7 +94,7 @@ class YoutubeParser extends Parser {
             }
             const channel: GoogleApiYouTubeChannelResource = channelJsonResponse.items[0];
 
-            const videoPlayer = `<iframe width="560" height="315" src="https://www.youtube.com/embed/${video.id}" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>`;
+            const videoPlayer = `<iframe width="${this.settings.youtubeEmbedWidth}" height="${this.settings.youtubeEmbedHeight}" src="https://www.youtube.com/embed/${video.id}" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>`;
             const duration = parse(video.contentDetails.duration);
             return {
                 id: video.id,
@@ -135,7 +135,7 @@ class YoutubeParser extends Parser {
             const videoSchemaElement = videoHTML.querySelector('[itemtype="http://schema.org/VideoObject"]');
             const videoId = videoSchemaElement?.querySelector('[itemprop="videoId"]')?.getAttribute('content') ?? '';
             const personSchemaElement = videoSchemaElement.querySelector('[itemtype="http://schema.org/Person"]');
-            const videoPlayer = `<iframe width="560" height="315" src="https://www.youtube.com/embed/${videoId}" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>`;
+            const videoPlayer = `<iframe width="${this.settings.youtubeEmbedWidth}" height="${this.settings.youtubeEmbedHeight}" src="https://www.youtube.com/embed/${videoId}" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>`;
 
             return {
                 id: videoId,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -4,10 +4,16 @@ export interface ReadItLaterSettings {
     openNewNote: boolean;
     youtubeNoteTitle: string;
     youtubeNote: string;
+    youtubeEmbedWidth: string;
+    youtubeEmbedHeight: string;
     vimeoNoteTitle: string;
     vimeoNote: string;
+    vimeoEmbedWidth: string;
+    vimeoEmbedHeight: string;
     bilibiliNoteTitle: string;
     bilibiliNote: string;
+    bilibiliEmbedWidth: string;
+    bilibiliEmbedHeight: string;
     twitterNoteTitle: string;
     twitterNote: string;
     parseableArticleNoteTitle: string;
@@ -34,6 +40,8 @@ export interface ReadItLaterSettings {
     youtubeApiKey: string;
     tikTokNoteTitle: string;
     tikTokNote: string;
+    tikTokEmbedWidth: string;
+    tikTokEmbedHeight: string;
 }
 
 export const DEFAULT_SETTINGS: ReadItLaterSettings = {
@@ -42,10 +50,16 @@ export const DEFAULT_SETTINGS: ReadItLaterSettings = {
     openNewNote: false,
     youtubeNoteTitle: 'Youtube - %title%',
     youtubeNote: '[[ReadItLater]] [[Youtube]]\n\n# [%videoTitle%](%videoURL%)\n\n%videoPlayer%',
+    youtubeEmbedWidth: '560',
+    youtubeEmbedHeight: '315',
     vimeoNoteTitle: 'Vimeo - %title%',
     vimeoNote: '[[ReadItLater]] [[Vimeo]]\n\n# [%videoTitle%](%videoURL%)\n\n%videoPlayer%',
+    vimeoEmbedWidth: '560',
+    vimeoEmbedHeight: '315',
     bilibiliNoteTitle: 'Bilibili - %title%',
     bilibiliNote: '[[ReadItLater]] [[Bilibili]]\n\n# [%videoTitle%](%videoURL%)\n\n%videoPlayer%',
+    bilibiliEmbedWidth: '560',
+    bilibiliEmbedHeight: '315',
     twitterNoteTitle: 'Tweet from %tweetAuthorName% (%date%)',
     twitterNote: '[[ReadItLater]] [[Tweet]]\n\n# [%tweetAuthorName%](%tweetURL%)\n\n%tweetContent%',
     parseableArticleNoteTitle: '%title%',
@@ -73,4 +87,6 @@ export const DEFAULT_SETTINGS: ReadItLaterSettings = {
     youtubeApiKey: '',
     tikTokNoteTitle: 'TikTok from %authorName% (%date%)',
     tikTokNote: '[[ReadItLater]] [[TikTok]]\n\n%videoDescription%\n\n[%videoURL%](%videoURL%)\n\n%videoPlayer%',
+    tikTokEmbedWidth: '325',
+    tikTokEmbedHeight: '760'
 };

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -88,5 +88,5 @@ export const DEFAULT_SETTINGS: ReadItLaterSettings = {
     tikTokNoteTitle: 'TikTok from %authorName% (%date%)',
     tikTokNote: '[[ReadItLater]] [[TikTok]]\n\n%videoDescription%\n\n[%videoURL%](%videoURL%)\n\n%videoPlayer%',
     tikTokEmbedWidth: '325',
-    tikTokEmbedHeight: '760'
+    tikTokEmbedHeight: '760',
 };

--- a/src/views/settings-tab.ts
+++ b/src/views/settings-tab.ts
@@ -129,29 +129,25 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
                     }),
             );
 
-        new Setting(containerEl)
-            .setName('Youtube embed player width')
-            .addText((text) =>
-                text
-                    .setPlaceholder(DEFAULT_SETTINGS.youtubeEmbedWidth)
-                    .setValue(this.plugin.settings.youtubeEmbedWidth || DEFAULT_SETTINGS.youtubeEmbedWidth)
-                    .onChange(async (value) => {
-                        this.plugin.settings.youtubeEmbedWidth = value;
-                        await this.plugin.saveSettings();
-                    }),
-            );
+        new Setting(containerEl).setName('Youtube embed player width').addText((text) =>
+            text
+                .setPlaceholder(DEFAULT_SETTINGS.youtubeEmbedWidth)
+                .setValue(this.plugin.settings.youtubeEmbedWidth || DEFAULT_SETTINGS.youtubeEmbedWidth)
+                .onChange(async (value) => {
+                    this.plugin.settings.youtubeEmbedWidth = value;
+                    await this.plugin.saveSettings();
+                }),
+        );
 
-        new Setting(containerEl)
-            .setName('Youtube embed player height')
-            .addText((text) =>
-                text
-                    .setPlaceholder(DEFAULT_SETTINGS.youtubeEmbedHeight)
-                    .setValue(this.plugin.settings.youtubeEmbedHeight || DEFAULT_SETTINGS.youtubeEmbedHeight)
-                    .onChange(async (value) => {
-                        this.plugin.settings.youtubeEmbedHeight = value;
-                        await this.plugin.saveSettings();
-                    }),
-            );
+        new Setting(containerEl).setName('Youtube embed player height').addText((text) =>
+            text
+                .setPlaceholder(DEFAULT_SETTINGS.youtubeEmbedHeight)
+                .setValue(this.plugin.settings.youtubeEmbedHeight || DEFAULT_SETTINGS.youtubeEmbedHeight)
+                .onChange(async (value) => {
+                    this.plugin.settings.youtubeEmbedHeight = value;
+                    await this.plugin.saveSettings();
+                }),
+        );
 
         containerEl.createEl('h2', { text: 'Vimeo' });
 
@@ -184,29 +180,25 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
                 textarea.inputEl.cols = 25;
             });
 
-        new Setting(containerEl)
-            .setName('Vimeo embed player width')
-            .addText((text) =>
-                text
-                    .setPlaceholder(DEFAULT_SETTINGS.vimeoEmbedWidth)
-                    .setValue(this.plugin.settings.vimeoEmbedWidth || DEFAULT_SETTINGS.vimeoEmbedWidth)
-                    .onChange(async (value) => {
-                        this.plugin.settings.vimeoEmbedWidth = value;
-                        await this.plugin.saveSettings();
-                    }),
-            );
+        new Setting(containerEl).setName('Vimeo embed player width').addText((text) =>
+            text
+                .setPlaceholder(DEFAULT_SETTINGS.vimeoEmbedWidth)
+                .setValue(this.plugin.settings.vimeoEmbedWidth || DEFAULT_SETTINGS.vimeoEmbedWidth)
+                .onChange(async (value) => {
+                    this.plugin.settings.vimeoEmbedWidth = value;
+                    await this.plugin.saveSettings();
+                }),
+        );
 
-        new Setting(containerEl)
-            .setName('Vimeo embed player height')
-            .addText((text) =>
-                text
-                    .setPlaceholder(DEFAULT_SETTINGS.vimeoEmbedHeight)
-                    .setValue(this.plugin.settings.vimeoEmbedHeight || DEFAULT_SETTINGS.vimeoEmbedHeight)
-                    .onChange(async (value) => {
-                        this.plugin.settings.vimeoEmbedHeight = value;
-                        await this.plugin.saveSettings();
-                    }),
-            );
+        new Setting(containerEl).setName('Vimeo embed player height').addText((text) =>
+            text
+                .setPlaceholder(DEFAULT_SETTINGS.vimeoEmbedHeight)
+                .setValue(this.plugin.settings.vimeoEmbedHeight || DEFAULT_SETTINGS.vimeoEmbedHeight)
+                .onChange(async (value) => {
+                    this.plugin.settings.vimeoEmbedHeight = value;
+                    await this.plugin.saveSettings();
+                }),
+        );
 
         containerEl.createEl('h2', { text: 'Bilibili' });
 
@@ -237,29 +229,25 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
                 textarea.inputEl.cols = 25;
             });
 
-        new Setting(containerEl)
-            .setName('Bilibili embed player width')
-            .addText((text) =>
-                text
-                    .setPlaceholder(DEFAULT_SETTINGS.bilibiliEmbedWidth)
-                    .setValue(this.plugin.settings.bilibiliEmbedWidth || DEFAULT_SETTINGS.bilibiliEmbedWidth)
-                    .onChange(async (value) => {
-                        this.plugin.settings.bilibiliEmbedWidth = value;
-                        await this.plugin.saveSettings();
-                    }),
-            );
+        new Setting(containerEl).setName('Bilibili embed player width').addText((text) =>
+            text
+                .setPlaceholder(DEFAULT_SETTINGS.bilibiliEmbedWidth)
+                .setValue(this.plugin.settings.bilibiliEmbedWidth || DEFAULT_SETTINGS.bilibiliEmbedWidth)
+                .onChange(async (value) => {
+                    this.plugin.settings.bilibiliEmbedWidth = value;
+                    await this.plugin.saveSettings();
+                }),
+        );
 
-        new Setting(containerEl)
-            .setName('Bilibili embed player height')
-            .addText((text) =>
-                text
-                    .setPlaceholder(DEFAULT_SETTINGS.bilibiliEmbedHeight)
-                    .setValue(this.plugin.settings.bilibiliEmbedHeight || DEFAULT_SETTINGS.bilibiliEmbedHeight)
-                    .onChange(async (value) => {
-                        this.plugin.settings.bilibiliEmbedHeight = value;
-                        await this.plugin.saveSettings();
-                    }),
-            );
+        new Setting(containerEl).setName('Bilibili embed player height').addText((text) =>
+            text
+                .setPlaceholder(DEFAULT_SETTINGS.bilibiliEmbedHeight)
+                .setValue(this.plugin.settings.bilibiliEmbedHeight || DEFAULT_SETTINGS.bilibiliEmbedHeight)
+                .onChange(async (value) => {
+                    this.plugin.settings.bilibiliEmbedHeight = value;
+                    await this.plugin.saveSettings();
+                }),
+        );
 
         containerEl.createEl('h2', { text: 'Twitter' });
 
@@ -495,29 +483,25 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
                 textarea.inputEl.cols = 25;
             });
 
-        new Setting(containerEl)
-            .setName('TikTok embed player width')
-            .addText((text) =>
-                text
-                    .setPlaceholder(DEFAULT_SETTINGS.tikTokEmbedWidth)
-                    .setValue(this.plugin.settings.tikTokEmbedWidth || DEFAULT_SETTINGS.tikTokEmbedWidth)
-                    .onChange(async (value) => {
-                        this.plugin.settings.tikTokEmbedWidth = value;
-                        await this.plugin.saveSettings();
-                    }),
-            );
+        new Setting(containerEl).setName('TikTok embed player width').addText((text) =>
+            text
+                .setPlaceholder(DEFAULT_SETTINGS.tikTokEmbedWidth)
+                .setValue(this.plugin.settings.tikTokEmbedWidth || DEFAULT_SETTINGS.tikTokEmbedWidth)
+                .onChange(async (value) => {
+                    this.plugin.settings.tikTokEmbedWidth = value;
+                    await this.plugin.saveSettings();
+                }),
+        );
 
-        new Setting(containerEl)
-            .setName('TikTok embed player height')
-            .addText((text) =>
-                text
-                    .setPlaceholder(DEFAULT_SETTINGS.tikTokEmbedHeight)
-                    .setValue(this.plugin.settings.tikTokEmbedHeight || DEFAULT_SETTINGS.tikTokEmbedHeight)
-                    .onChange(async (value) => {
-                        this.plugin.settings.tikTokEmbedHeight = value;
-                        await this.plugin.saveSettings();
-                    }),
-            );
+        new Setting(containerEl).setName('TikTok embed player height').addText((text) =>
+            text
+                .setPlaceholder(DEFAULT_SETTINGS.tikTokEmbedHeight)
+                .setValue(this.plugin.settings.tikTokEmbedHeight || DEFAULT_SETTINGS.tikTokEmbedHeight)
+                .onChange(async (value) => {
+                    this.plugin.settings.tikTokEmbedHeight = value;
+                    await this.plugin.saveSettings();
+                }),
+        );
 
         containerEl.createEl('h2', { text: 'Readable Article' });
 

--- a/src/views/settings-tab.ts
+++ b/src/views/settings-tab.ts
@@ -129,6 +129,30 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
                     }),
             );
 
+        new Setting(containerEl)
+            .setName('Youtube embed player width')
+            .addText((text) =>
+                text
+                    .setPlaceholder(DEFAULT_SETTINGS.youtubeEmbedWidth)
+                    .setValue(this.plugin.settings.youtubeEmbedWidth || DEFAULT_SETTINGS.youtubeEmbedWidth)
+                    .onChange(async (value) => {
+                        this.plugin.settings.youtubeEmbedWidth = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
+
+        new Setting(containerEl)
+            .setName('Youtube embed player height')
+            .addText((text) =>
+                text
+                    .setPlaceholder(DEFAULT_SETTINGS.youtubeEmbedHeight)
+                    .setValue(this.plugin.settings.youtubeEmbedHeight || DEFAULT_SETTINGS.youtubeEmbedHeight)
+                    .onChange(async (value) => {
+                        this.plugin.settings.youtubeEmbedHeight = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
+
         containerEl.createEl('h2', { text: 'Vimeo' });
 
         new Setting(containerEl)
@@ -160,6 +184,30 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
                 textarea.inputEl.cols = 25;
             });
 
+        new Setting(containerEl)
+            .setName('Vimeo embed player width')
+            .addText((text) =>
+                text
+                    .setPlaceholder(DEFAULT_SETTINGS.vimeoEmbedWidth)
+                    .setValue(this.plugin.settings.vimeoEmbedWidth || DEFAULT_SETTINGS.vimeoEmbedWidth)
+                    .onChange(async (value) => {
+                        this.plugin.settings.vimeoEmbedWidth = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
+
+        new Setting(containerEl)
+            .setName('Vimeo embed player height')
+            .addText((text) =>
+                text
+                    .setPlaceholder(DEFAULT_SETTINGS.vimeoEmbedHeight)
+                    .setValue(this.plugin.settings.vimeoEmbedHeight || DEFAULT_SETTINGS.vimeoEmbedHeight)
+                    .onChange(async (value) => {
+                        this.plugin.settings.vimeoEmbedHeight = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
+
         containerEl.createEl('h2', { text: 'Bilibili' });
 
         new Setting(containerEl)
@@ -188,6 +236,30 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
                 textarea.inputEl.rows = 10;
                 textarea.inputEl.cols = 25;
             });
+
+        new Setting(containerEl)
+            .setName('Bilibili embed player width')
+            .addText((text) =>
+                text
+                    .setPlaceholder(DEFAULT_SETTINGS.bilibiliEmbedWidth)
+                    .setValue(this.plugin.settings.bilibiliEmbedWidth || DEFAULT_SETTINGS.bilibiliEmbedWidth)
+                    .onChange(async (value) => {
+                        this.plugin.settings.bilibiliEmbedWidth = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
+
+        new Setting(containerEl)
+            .setName('Bilibili embed player height')
+            .addText((text) =>
+                text
+                    .setPlaceholder(DEFAULT_SETTINGS.bilibiliEmbedHeight)
+                    .setValue(this.plugin.settings.bilibiliEmbedHeight || DEFAULT_SETTINGS.bilibiliEmbedHeight)
+                    .onChange(async (value) => {
+                        this.plugin.settings.bilibiliEmbedHeight = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
         containerEl.createEl('h2', { text: 'Twitter' });
 
@@ -422,6 +494,30 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
                 textarea.inputEl.rows = 10;
                 textarea.inputEl.cols = 25;
             });
+
+        new Setting(containerEl)
+            .setName('TikTok embed player width')
+            .addText((text) =>
+                text
+                    .setPlaceholder(DEFAULT_SETTINGS.tikTokEmbedWidth)
+                    .setValue(this.plugin.settings.tikTokEmbedWidth || DEFAULT_SETTINGS.tikTokEmbedWidth)
+                    .onChange(async (value) => {
+                        this.plugin.settings.tikTokEmbedWidth = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
+
+        new Setting(containerEl)
+            .setName('TikTok embed player height')
+            .addText((text) =>
+                text
+                    .setPlaceholder(DEFAULT_SETTINGS.tikTokEmbedHeight)
+                    .setValue(this.plugin.settings.tikTokEmbedHeight || DEFAULT_SETTINGS.tikTokEmbedHeight)
+                    .onChange(async (value) => {
+                        this.plugin.settings.tikTokEmbedHeight = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
         containerEl.createEl('h2', { text: 'Readable Article' });
 


### PR DESCRIPTION
# Description

This PR add new settings to customize size of embedded players in iframe element.

## Motivation and Context

Feature request by user in issues.

## How has this been tested?

By editing settings, checking saved data in data.json and creating notes with embedded player.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content)

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `npm run lint`.
- [ ] My change requires an update of README.md
- [ ] I have updated the README.md
