### PR TITLE
feat: Extend share menu with plugin shortcut

### DIFF
--- a/src/parsers/ParserCreator.ts
+++ b/src/parsers/ParserCreator.ts
@@ -1,0 +1,17 @@
+import { Parser } from './Parser';
+
+export default class ParserCreator {
+    private parsers: Parser[];
+
+    constructor(parsers: Parser[]) {
+        this.parsers = parsers;
+    }
+
+    public async createParser(content: string): Promise<Parser> {
+        for (const parser of this.parsers) {
+            if (await parser.test(content)) {
+                return parser;
+            }
+        }
+    }
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -42,6 +42,7 @@ export interface ReadItLaterSettings {
     tikTokNote: string;
     tikTokEmbedWidth: string;
     tikTokEmbedHeight: string;
+    extendShareMenu: boolean;
 }
 
 export const DEFAULT_SETTINGS: ReadItLaterSettings = {
@@ -89,4 +90,5 @@ export const DEFAULT_SETTINGS: ReadItLaterSettings = {
     tikTokNote: '[[ReadItLater]] [[TikTok]]\n\n%videoDescription%\n\n[%videoURL%](%videoURL%)\n\n%videoPlayer%',
     tikTokEmbedWidth: '325',
     tikTokEmbedHeight: '760',
+    extendShareMenu: true,
 };

--- a/src/views/settings-tab.ts
+++ b/src/views/settings-tab.ts
@@ -85,6 +85,24 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
                     }),
             );
 
+        new Setting(containerEl)
+            .setName('Extend share menu')
+            .setDesc(
+                'If enabled, share menu will be extended with shortcut to create note directly from it. Requires plugin reload or Obsidian restart to apply change.',
+            )
+            .addToggle((toggle) =>
+                toggle
+                    .setValue(
+                        Object.prototype.hasOwnProperty.call(this.plugin.settings, 'extendShareMenu')
+                            ? this.plugin.settings.extendShareMenu
+                            : DEFAULT_SETTINGS.extendShareMenu,
+                    )
+                    .onChange(async (value) => {
+                        this.plugin.settings.extendShareMenu = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
+
         containerEl.createEl('h2', { text: 'YouTube' });
 
         new Setting(containerEl)


### PR DESCRIPTION
# Description

This PR extends Obsidian share menu with plugin shortcut to quickly create new note. I also added new setting to toggle this functionality because API method, which provides it, is not yet public in Obsidian API.

## Motivation and Context

This feature was request by user in issues but it's great UX improvement for plugin users.

## How has this been tested?

Latest Obsidian Mobile app on Android 10 and iOS15.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content)

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `npm run lint`.
- [ ] My change requires an update of README.md
- [ ] I have updated the README.md
