### PR TITLE
fix: Bilibili embed autoplay

### DIFF
--- a/src/parsers/BilibiliParser.ts
+++ b/src/parsers/BilibiliParser.ts
@@ -26,7 +26,7 @@ class BilibiliParser extends Parser {
         const videoHTML = new DOMParser().parseFromString(response, 'text/html');
         const videoTitle = videoHTML.querySelector("[property~='og:title']").getAttribute('content');
         const videoId = this.PATTERN.exec(url)[3];
-        const videoPlayer = `<iframe width="${this.settings.bilibiliEmbedWidth}" height="${this.settings.bilibiliEmbedHeight}" src="https://player.bilibili.com/player.html?bvid=${videoId}" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true"></iframe>`;
+        const videoPlayer = `<iframe width="${this.settings.bilibiliEmbedWidth}" height="${this.settings.bilibiliEmbedHeight}" src="https://player.bilibili.com/player.html?autoplay=0&bvid=${videoId}" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true"></iframe>`;
 
         const content = this.settings.bilibiliNote
             .replace(/%date%/g, this.getFormattedDateForContent())


### PR DESCRIPTION
# Description

Bilibili embed player autoplays content by default. This behavior results in simultaneous playbacks in reading and editing mode. This fix adds ```autoplay=0``` query parameter to player URL which prevents autoplay.

## Motivation and Context

#102 

## How has this been tested?

Tested by creating new note from this Bilibili video: https://www.bilibili.com/video/BV1ru41147xd/

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content)

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `npm run lint`.
- [ ] My change requires an update of README.md
- [ ] I have updated the README.md
