### PR TITLE
feat: adds setting option to escape tags in YT Description

### DIFF
--- a/src/parsers/YoutubeParser.ts
+++ b/src/parsers/YoutubeParser.ts
@@ -102,7 +102,7 @@ class YoutubeParser extends Parser {
                 id: video.id,
                 url: url,
                 title: video.snippet.title,
-                description: video.snippet.description,
+                description: this.escapeTagsInYouTubeDescription(video.snippet.description, this.settings.youtubeDescTagEscape),
                 thumbnail: video.snippet.thumbnails.default.url,
                 player: videoPlayer,
                 duration: toSeconds(duration),
@@ -195,6 +195,15 @@ class YoutubeParser extends Parser {
         }
 
         return formatted.trim();
+    }
+
+    private escapeTagsInYouTubeDescription(ytDesc: string, tagSetting: boolean): string {
+
+        if(tagSetting == true) {
+            return ytDesc.replaceAll('#','\\#')
+        } else {
+            return ytDesc;
+        }
     }
 }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,6 +6,7 @@ export interface ReadItLaterSettings {
     youtubeNote: string;
     youtubeEmbedWidth: string;
     youtubeEmbedHeight: string;
+    youtubeDescTagEscape: boolean;
     vimeoNoteTitle: string;
     vimeoNote: string;
     vimeoEmbedWidth: string;
@@ -53,6 +54,7 @@ export const DEFAULT_SETTINGS: ReadItLaterSettings = {
     youtubeNote: '[[ReadItLater]] [[Youtube]]\n\n# [%videoTitle%](%videoURL%)\n\n%videoPlayer%',
     youtubeEmbedWidth: '560',
     youtubeEmbedHeight: '315',
+    youtubeDescTagEscape: false,
     vimeoNoteTitle: 'Vimeo - %title%',
     vimeoNote: '[[ReadItLater]] [[Vimeo]]\n\n# [%videoTitle%](%videoURL%)\n\n%videoPlayer%',
     vimeoEmbedWidth: '560',

--- a/src/views/settings-tab.ts
+++ b/src/views/settings-tab.ts
@@ -136,7 +136,7 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
 
         new Setting(containerEl)
             .setName('Youtube Data API v3 key')
-            .setDesc('If entered, additional template variables are available')
+            .setDesc('If entered, these additional template variables are available: %videoDescription%, %videoDuration%, %videoDurationFormatted%, %videoPublishDate%, %videoThumbnail%, %videoTags%, %videoViewsCount%.')
             .addText((text) =>
                 text
                     .setPlaceholder('')
@@ -163,6 +163,24 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
                 .setValue(this.plugin.settings.youtubeEmbedHeight || DEFAULT_SETTINGS.youtubeEmbedHeight)
                 .onChange(async (value) => {
                     this.plugin.settings.youtubeEmbedHeight = value;
+                    await this.plugin.saveSettings();
+                }),
+        );
+
+        new Setting(containerEl)
+        .setName('Escape Tags in YouTube Description')
+        .setDesc(
+            'If enabled, any tags within the YouTube description will be escaped so they don\'t contribute to tags within your vault.',
+        )
+        .addToggle((toggle) =>
+            toggle
+                .setValue(
+                    Object.prototype.hasOwnProperty.call(this.plugin.settings, 'youtubeDescTagEscape')
+                        ? this.plugin.settings.youtubeDescTagEscape
+                        : DEFAULT_SETTINGS.youtubeDescTagEscape,
+                )
+                .onChange(async (value) => {
+                    this.plugin.settings.youtubeDescTagEscape = value;
                     await this.plugin.saveSettings();
                 }),
         );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
       "es5",
       "es6",
       "es7",
-      "scripthost"
+      "scripthost",
+      "ES2021.String"
     ]
   },
   "include": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Sometimes YouTube videos contain tons of tags within the video description. (A lot of news agencies add in dozens). I wanted the ability to escape their tags so they don't contribute to the tags in my vault.

# Description

List of changes:
- Adds a setting in the YouTube Section called "Escape Tags in YouTube Description".
- When true it adds a backslash in front of all tags
- Added `ES2021.String` to the tsconfig so I could use .replaceAll() on the description.
- I adjusted the description for the YouTube data API key in settings to include the options it adds. I did this because it didn't seem to make sense to have a setting to escape tags in the video description without the option listed for the video description noted anywhere on the settings page.

<!--- Describe your changes in detail -->

## Motivation and Context

Again this keeps tags in my vault my own without the need to wrap the entire description in a code block which is what I have been doing. 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

Tested in a test vault with various different youtube videos. 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content)

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `npm run lint`.
- [ ] My change requires an update of README.md
- [ ] I have updated the README.md
