### PR TITLE
feat: add preview image URL variable to articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,13 +195,14 @@ If enabled, images will be downloaded to folder (default is `ReadItLater Inbox/a
 | %title%                 | `<title>` HTML element                      |
 | %date%                  | Current date in format from plugin settings |
 
-| Content template variable | Retrieved from                              |
-| ------------------------- | ------------------------------------------- |
-| %articleTitle%            | `<title>` HTML element                      |
-| %articleURL%              | URL from clipboard                          |
-| %articleReadingTime%      | Estimated reading time                      |
-| %articleContent%          | Parsed `<body>` HTML element                |
-| %date%                    | Current date in format from plugin settings |
+| Content template variable | Retrieved from                                                                                                                                                     |
+|---------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| %articleTitle%            | `<title>` HTML element                                                                                                                                             |
+| %articleURL%              | URL from clipboard                                                                                                                                                 |
+| %articleReadingTime%      | Estimated reading time                                                                                                                                             |
+| %articleContent%          | Parsed `<body>` HTML element                                                                                                                                       |
+| %date%                    | Current date in format from plugin settings                                                                                                                        |
+| %previewURL%              | Extracted from [OpenGraph](https://ogp.me/) or [Twitter](https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup) image `<meta>` property |
 
 ### Text Snippet
 

--- a/src/parsers/WebsiteParser.ts
+++ b/src/parsers/WebsiteParser.ts
@@ -68,7 +68,7 @@ class WebsiteParser extends Parser {
         const title = article.title || 'No title';
         const siteName = article.siteName || '';
         const author = article.byline || '';
-        let content = await parseHtmlContent(article.content);
+        const content = await parseHtmlContent(article.content);
 
         const fileNameTemplate = this.settings.parseableArticleNoteTitle
             .replace(/%title%/g, title)
@@ -78,11 +78,7 @@ class WebsiteParser extends Parser {
             ? `${this.settings.assetsDir}/${normalizeFilename(fileNameTemplate)}/`
             : this.settings.assetsDir;
 
-        if (this.settings.downloadImages && Platform.isDesktop) {
-            content = await replaceImages(app, content, assetsDir);
-        }
-
-        const processedContent = this.settings.parsableArticleNote
+        let processedContent = this.settings.parsableArticleNote
             .replace(/%date%/g, this.getFormattedDateForContent())
             .replace(/%articleTitle%/g, title)
             .replace(/%articleURL%/g, url)
@@ -91,6 +87,10 @@ class WebsiteParser extends Parser {
             .replace(/%siteName%/g, siteName)
             .replace(/%author%/g, author)
             .replace(/%previewURL%/g, previewUrl || '');
+
+        if (this.settings.downloadImages && Platform.isDesktop) {
+            processedContent = await replaceImages(app, processedContent, assetsDir);
+        }
 
         const fileName = `${fileNameTemplate}.md`;
         return new Note(fileName, processedContent);

--- a/src/views/settings-tab.ts
+++ b/src/views/settings-tab.ts
@@ -541,7 +541,7 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
         new Setting(containerEl)
             .setName('Readable article note template')
             .setDesc(
-                'Available variables: %date%, %articleTitle%, %articleURL%, %articleContent%, %author%, %siteName%, %articleReadingTime%',
+                'Available variables: %date%, %articleTitle%, %articleURL%, %articleContent%, %author%, %siteName%, %articleReadingTime%, %previewURL%',
             )
             .addTextArea((textarea) => {
                 textarea
@@ -607,7 +607,7 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
 
         new Setting(containerEl)
             .setName('Nonreadable article note template')
-            .setDesc('Available variables: %date%, %articleURL%')
+            .setDesc('Available variables: %date%, %articleURL%, %previewURL%')
             .addTextArea((textarea) => {
                 textarea
                     .setValue(this.plugin.settings.notParsableArticleNote || DEFAULT_SETTINGS.notParsableArticleNote)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Add a `%previewURL%` variable containing the URL to the article preview image. The preview image is extracted from the DOM using the [OpenGraph](https://ogp.me/) `og:image` or the [Twitter](https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup) `twitter:image` meta tags. These two meta tags seem to be the most popular ones.

Small structure changes in the `WebsiteParser` file: avoiding wrapping promises, factorization of `replaceImages` and using `this.app` instead of passing it as a parameter.

## Motivation and Context
I'm using this great plugin with the DataView plugin to display my items to read using a Card view. I really lacked an image to illustrate all my links. I was manually adding the preview image myself to the notes (sometimes using the dev tools to get the infos from the meta tags), so I decided to make it a feature of this plugin.

I hope this will be usefull to someone else!

## How has this been tested?

Tested using multiple website both with or without the OpenGraph or Twitter tag.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content)

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `npm run lint`.
- [x] My change requires an update of README.md
- [x] I have updated the README.md
