### PR TITLE
fix: Edit regex to support x.com in TwitterParser

### DIFF
--- a/src/parsers/TwitterParser.ts
+++ b/src/parsers/TwitterParser.ts
@@ -5,7 +5,7 @@ import { Note } from './Note';
 import { parseHtmlContent } from './parsehtml';
 
 class TwitterParser extends Parser {
-    private PATTERN = /(https:\/\/twitter.com\/([a-zA-Z0-9_]+\/)([a-zA-Z0-9_]+\/[a-zA-Z0-9_]+))/;
+    private PATTERN = /(https:\/\/(twitter|x).com\/([a-zA-Z0-9_]+\/)([a-zA-Z0-9_]+\/[a-zA-Z0-9_]+))/;
 
     constructor(app: App, settings: ReadItLaterSettings) {
         super(app, settings);
@@ -16,11 +16,17 @@ class TwitterParser extends Parser {
     }
 
     async prepareNote(url: string): Promise<Note> {
+        const twitterUrl = new URL(url);
+
+        if (twitterUrl.hostname === 'x.com') {
+            twitterUrl.hostname = 'twitter.com';
+        }
+
         const response = JSON.parse(
             await request({
                 method: 'GET',
                 contentType: 'application/json',
-                url: `https://publish.twitter.com/oembed?url=${url}`,
+                url: `https://publish.twitter.com/oembed?url=${twitterUrl.href}`,
             }),
         );
 


### PR DESCRIPTION
# Description

This PR adds support for new Twitter domain - x.com. However, this domain is not supported by Twitter Publish API, so internally is overwritten to twitter.com.

## Motivation and Context

Issue reported by user.

## How has this been tested?

By saving public post - https://x.com/Windycom/status/1702327699564564602

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content)

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `npm run lint`.
- [ ] My change requires an update of README.md
- [ ] I have updated the README.md
