### PR TITLE
feat!!: Adds ability to embed images as base64 encoded strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,9 +187,15 @@ Will be converted to note with embeded player in `<iframe>`.
 
 ### Website URL
 
-Will be parsed to readable form using [Mozilla Readability](https://github.com/mozilla/readability) and then converted to markdown. In case website content is marked by [Readbility](https://github.com/mozilla/readability) as not readable, empty note with URL will be created. 
+The website will be parsed to readable form using [Mozilla Readability](https://github.com/mozilla/readability) and then converted to markdown. If [Readbility](https://github.com/mozilla/readability) cannot parse the website content, an empty note with the URL will be created.
 
-If enabled, images will be downloaded to folder (default is `ReadItLater Inbox/assets`) configured in plugin settings. (Supported only on desktop for now)
+Images can be optionally downloaded and either:
+- Saved to the the assets directory configured in the plugin settings (default: `ReadItLater Inbox/assets`),
+- Saved to a note-specific folder within the assets directory, or
+- Embedded in the note as a base64 encoded string
+
+Saving images to a directory is currently only supported on the Obsidian desktop app.
+
 
 | Title template variable | Retrieved from                              |
 | ------------------------| ------------------------------------------- |

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,3 +1,12 @@
+
+export enum ImageBehavior {
+    SaveToAssetDir = "save_to_asset_directory",
+    SaveToNoteDir = "save_to_note_directory",
+    EmbedBase64 = "embed_images_using_base64",
+    DoNotSave = "do_not_save_images"
+}
+
+
 export interface ReadItLaterSettings {
     inboxDir: string;
     assetsDir: string;
@@ -25,19 +34,16 @@ export interface ReadItLaterSettings {
     textSnippetNote: string;
     mastodonNoteTitle: string;
     mastodonNote: string;
-    downloadImages: boolean;
-    downloadImagesInArticleDir: boolean;
+    articleImageBehavior: ImageBehavior;
     dateTitleFmt: string;
     dateContentFmt: string;
-    downloadMastodonMediaAttachments: boolean;
-    downloadMastodonMediaAttachmentsInDir: boolean;
+    mastodonImageBehavior: ImageBehavior;
     saveMastodonReplies: boolean;
     mastodonReply: string;
     stackExchangeNoteTitle: string;
     stackExchangeNote: string;
     stackExchangeAnswer: string;
-    downloadStackExchangeAssets: boolean;
-    downloadStackExchangeAssetsInDir: boolean;
+    stackExchangeImageBehavior: ImageBehavior;
     youtubeApiKey: string;
     tikTokNoteTitle: string;
     tikTokNote: string;
@@ -73,20 +79,17 @@ export const DEFAULT_SETTINGS: ReadItLaterSettings = {
     textSnippetNote: '[[ReadItLater]] [[Textsnippet]]\n\n%content%',
     mastodonNoteTitle: 'Toot from %tootAuthorName% (%date%)',
     mastodonNote: '[[ReadItLater]] [[Toot]]\n\n# [%tootAuthorName%](%tootURL%)\n\n> %tootContent%',
-    downloadImages: true,
-    downloadImagesInArticleDir: false,
+    articleImageBehavior: ImageBehavior.SaveToAssetDir,
     dateTitleFmt: 'YYYY-MM-DD HH-mm-ss',
     dateContentFmt: 'YYYY-MM-DD',
-    downloadMastodonMediaAttachments: true,
-    downloadMastodonMediaAttachmentsInDir: false,
+    mastodonImageBehavior: ImageBehavior.SaveToAssetDir,
     saveMastodonReplies: false,
     mastodonReply: '[%tootAuthorName%](%tootURL%)\n\n> %tootContent%',
     stackExchangeNoteTitle: '%title%',
     stackExchangeNote:
         '[[ReadItLater]] [[StackExchange]]\n\n# [%questionTitle%](%questionURL%)\n\nAuthor: [%authorName%](%authorProfileURL%)\n\n%questionContent%\n\n***\n\n%topAnswer%\n\n%answers%',
     stackExchangeAnswer: 'Answered by: [%authorName%](%authorProfileURL%)\n\n%answerContent%',
-    downloadStackExchangeAssets: true,
-    downloadStackExchangeAssetsInDir: false,
+    stackExchangeImageBehavior: ImageBehavior.SaveToAssetDir,
     youtubeApiKey: '',
     tikTokNoteTitle: 'TikTok from %authorName% (%date%)',
     tikTokNote: '[[ReadItLater]] [[TikTok]]\n\n%videoDescription%\n\n[%videoURL%](%videoURL%)\n\n%videoPlayer%',

--- a/src/views/settings-tab.ts
+++ b/src/views/settings-tab.ts
@@ -1,6 +1,6 @@
 import { App, PluginSettingTab, Setting } from 'obsidian';
 import ReadItLaterPlugin from 'src/main';
-import { DEFAULT_SETTINGS } from 'src/settings';
+import { DEFAULT_SETTINGS, ImageBehavior } from 'src/settings';
 
 export class ReadItLaterSettingsTab extends PluginSettingTab {
     plugin: ReadItLaterPlugin;
@@ -358,37 +358,22 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
                 textarea.inputEl.cols = 25;
             });
 
-        new Setting(containerEl)
-            .setName('Download media attachments')
-            .setDesc('If enabled, media attachments are downloaded to the assets folder (only Desktop App feature)')
-            .addToggle((toggle) =>
-                toggle
-                    .setValue(
-                        Object.prototype.hasOwnProperty.call(this.plugin.settings, 'downloadStackExchangeAssets')
-                            ? this.plugin.settings.downloadStackExchangeAssets
-                            : DEFAULT_SETTINGS.downloadStackExchangeAssets,
-                    )
-                    .onChange(async (value) => {
-                        this.plugin.settings.downloadStackExchangeAssets = value;
-                        stackExchangeMediaAttachmentsInDirSetting.setDisabled(!value);
-                        await this.plugin.saveSettings();
-                    }),
-            );
 
-        const stackExchangeMediaAttachmentsInDirSetting = new Setting(containerEl)
-            .setName('Download media attachments to folder')
-            .setDesc('If enabled, the media attachments are stored in their own folder.')
-            .addToggle((toggle) =>
-                toggle
-                    .setValue(
-                        Object.prototype.hasOwnProperty.call(this.plugin.settings, 'downloadStackExchangeAssetsInDir')
-                            ? this.plugin.settings.downloadStackExchangeAssetsInDir
-                            : DEFAULT_SETTINGS.downloadStackExchangeAssetsInDir,
-                    )
-                    .onChange(async (value) => {
-                        this.plugin.settings.downloadStackExchangeAssetsInDir = value;
-                        await this.plugin.saveSettings();
-                    }),
+        new Setting(containerEl)
+            .setName('Image Behavior')
+            .setDesc(
+                'Specify how images should be handled. Note: Images can only be downloaded to the asset directory or a note-specific sub-directory using the Obsidian Desktop app.',
+            )
+            .addDropdown(level => level
+                .addOption("save_to_asset_directory", "Save Images to Asset Directory")
+                .addOption("save_to_note_directory", "Save Images to Note-specific Directory")
+                .addOption("embed_images_using_base64", "Embed Images in Note (base64 encoded)")
+                .addOption("do_not_save_images", "Do Not Save Images")
+                .setValue(this.plugin.settings.stackExchangeImageBehavior)
+                .onChange(async (value: ImageBehavior) => {
+                    this.plugin.settings.stackExchangeImageBehavior = value;
+                    await this.plugin.saveSettings();
+                })
             );
 
         containerEl.createEl('h2', { text: 'Mastodon' });
@@ -420,42 +405,22 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
                 textarea.inputEl.cols = 25;
             });
 
-        new Setting(containerEl)
-            .setName('Download media attachments')
-            .setDesc(
-                'If enabled, media attachments of toot are downloaded to the assets folder (only Desktop App feature)',
-            )
-            .addToggle((toggle) =>
-                toggle
-                    .setValue(
-                        Object.prototype.hasOwnProperty.call(this.plugin.settings, 'downloadMastodonMediaAttachments')
-                            ? this.plugin.settings.downloadMastodonMediaAttachments
-                            : DEFAULT_SETTINGS.downloadMastodonMediaAttachments,
-                    )
-                    .onChange(async (value) => {
-                        this.plugin.settings.downloadMastodonMediaAttachments = value;
-                        mastodonMediaAttachmentsInDirSetting.setDisabled(!value);
-                        await this.plugin.saveSettings();
-                    }),
-            );
 
-        const mastodonMediaAttachmentsInDirSetting = new Setting(containerEl)
-            .setName('Download media attachments to folder')
-            .setDesc('If enabled, the media attachments of toot are stored in their own folder.')
-            .addToggle((toggle) =>
-                toggle
-                    .setValue(
-                        Object.prototype.hasOwnProperty.call(
-                            this.plugin.settings,
-                            'downloadMastodonMediaAttachmentsInDir',
-                        )
-                            ? this.plugin.settings.downloadMastodonMediaAttachmentsInDir
-                            : DEFAULT_SETTINGS.downloadMastodonMediaAttachmentsInDir,
-                    )
-                    .onChange(async (value) => {
-                        this.plugin.settings.downloadMastodonMediaAttachmentsInDir = value;
-                        await this.plugin.saveSettings();
-                    }),
+        new Setting(containerEl)
+            .setName('Image Behavior')
+            .setDesc(
+                'Specify how images should be handled. Note: Images can only be downloaded to the asset directory or a note-specific sub-directory using the Obsidian Desktop app.',
+            )
+            .addDropdown(level => level
+                .addOption("save_to_asset_directory", "Save Images to Asset Directory")
+                .addOption("save_to_note_directory", "Save Images to Note-specific Directory")
+                .addOption("embed_images_using_base64", "Embed Images in Note (base64 encoded)")
+                .addOption("do_not_save_images", "Do Not Save Images")
+                .setValue(this.plugin.settings.mastodonImageBehavior)
+                .onChange(async (value: ImageBehavior) => {
+                    this.plugin.settings.mastodonImageBehavior = value;
+                    await this.plugin.saveSettings();
+                })
             );
 
         new Setting(containerEl)
@@ -573,36 +538,20 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
             });
 
         new Setting(containerEl)
-            .setName('Download images')
-            .setDesc('If enabled, images in article are downloaded to the assets folder (only Desktop App feature)')
-            .addToggle((toggle) =>
-                toggle
-                    .setValue(
-                        Object.prototype.hasOwnProperty.call(this.plugin.settings, 'downloadImages')
-                            ? this.plugin.settings.downloadImages
-                            : DEFAULT_SETTINGS.downloadImages,
-                    )
-                    .onChange(async (value) => {
-                        this.plugin.settings.downloadImages = value;
-                        imagesInArticleDirSettings.setDisabled(!value);
-                        await this.plugin.saveSettings();
-                    }),
-            );
-
-        const imagesInArticleDirSettings = new Setting(containerEl)
-            .setName('Download images to note folder')
-            .setDesc('If enabled, the images in article are stored in their own folder.')
-            .addToggle((toggle) =>
-                toggle
-                    .setValue(
-                        Object.prototype.hasOwnProperty.call(this.plugin.settings, 'downloadImagesInArticleDir')
-                            ? this.plugin.settings.downloadImagesInArticleDir
-                            : DEFAULT_SETTINGS.downloadImagesInArticleDir,
-                    )
-                    .onChange(async (value) => {
-                        this.plugin.settings.downloadImagesInArticleDir = value;
-                        await this.plugin.saveSettings();
-                    }),
+            .setName('Image Behavior')
+            .setDesc(
+                'Specify how images should be handled. Note: Images can only be downloaded to the asset directory or a note-specific sub-directory using the Obsidian Desktop app.',
+            )
+            .addDropdown(level => level
+                .addOption("save_to_asset_directory", "Save Images to Asset Directory")
+                .addOption("save_to_note_directory", "Save Images to Note-specific Directory")
+                .addOption("embed_images_using_base64", "Embed Images in Note (base64 encoded)")
+                .addOption("do_not_save_images", "Do Not Save Images")
+                .setValue(this.plugin.settings.articleImageBehavior)
+                .onChange(async (value: ImageBehavior) => {
+                    this.plugin.settings.articleImageBehavior = value;
+                    await this.plugin.saveSettings();
+                })
             );
 
         containerEl.createEl('h2', { text: 'Nonreadable Article' });
@@ -615,7 +564,7 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
                     .setPlaceholder("Defaults to 'Article %date%'")
                     .setValue(
                         this.plugin.settings.notParseableArticleNoteTitle ||
-                            DEFAULT_SETTINGS.notParseableArticleNoteTitle,
+                        DEFAULT_SETTINGS.notParseableArticleNoteTitle,
                     )
                     .onChange(async (value) => {
                         this.plugin.settings.notParseableArticleNoteTitle = value;


### PR DESCRIPTION
# Description

- Adds ability to embed images into a note as a base64 encoded string, similar to SingleFile
- Adds embed option to settings
- Refactors image download settings to use a dropdown instead of multiple toggles

## Motivation and Context

Bottom Line: It makes a note completely self-contained and is useful for archiving references. A dropdown was the most clear way to add the option to the settings.

I really like how easy ReadItLater makes importing articles from the internet, both to archive references in case they disappears or simply to allow searching the contents as part of my knowledge base. My main frustration was that images were stored separately since Markdown is a plaintext format, and I thought this might get difficult to manage / clean out. (I also didn't notice / fully understand the functionality of the "Download to note folder" option until I was mostly done implementing my feature.)

While researching options for archiving articles, I came across [SingleFile](https://github.com/gildas-lormeau/SingleFile) and liked that it packaged everything into a single, self-contained file that could be easily moved around or deleted, taking all of its associated resources with it. I figured the same technique could be implemented as an Obsidian plugin and decided to give it a shot.

I found the multiple toggles to be confusing and didn't want to complicate things more by adding a toggle for embedding. Since the download options were mutually exclusive, I converted the two toggles per feature (i.e., stack exchange, mastodon, readable article) to a dropdown list, since the download options were mutually exclusive.

## How has this been tested?

1. Built the plugin using the `mcr.microsoft.com/devcontainers/typescript-node:1-20-bullseye` Dev Container in Visual Studio Code (npm 9.8.1)
2. Copied the `main.js` and `manifest.json` files to the `.obsidian\plugins\obsidian-read-it-later` directory of a test vault (Obsidian 1.4.14 and Obsidian 1.4.16; Desktop app on a Windows 11 computer) and reloaded Obsidian to pick up the changes
3. Manually tested all four options (i.e., save to asset directory, save to note directory, embed as base64, don't save images) for each of the three affected features (i.e., stack exchange, mastodon, readable article)
4. Verified the images were handled properly in all cases and rendered successfully when in reading mode

## Screenshots (if appropriate)

## Types of changes

Changes visible to users:

- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [x] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
  - **Note**: Due to the way settings have changed, the default "save to assets directory" option will be applied, and users will have to select their preferred setting from the dropdown. It might be safer to change the default to save to a per-note directory 
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content)

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

- [x] My code follows the code style of this project and passes `npm run lint`.
- [ ] My change requires an update of README.md
- [x] I have updated the README.md
