### PR TITLE
Add missing %date% variables to answer template

### DIFF
--- a/src/parsers/StackExchangeParser.ts
+++ b/src/parsers/StackExchangeParser.ts
@@ -48,6 +48,7 @@ class StackExchangeParser extends Parser {
 
         const topAnswer = question.topAnswer
             ? this.settings.stackExchangeAnswer
+                  .replace(/%date%/g, this.getFormattedDateForContent())
                   .replace(/%answerContent%/g, question.topAnswer.content)
                   .replace(/%authorName%/g, question.topAnswer.author.name)
                   .replace(/%authorProfileURL%/g, question.topAnswer.author.profile)
@@ -56,6 +57,7 @@ class StackExchangeParser extends Parser {
         let answers = '';
         for (let i = 0; i < question.answers.length; i++) {
             const answer = this.settings.stackExchangeAnswer
+                .replace(/%date%/g, this.getFormattedDateForContent())
                 .replace(/%answerContent%/g, question.answers[i].content)
                 .replace(/%authorName%/g, question.answers[i].author.name)
                 .replace(/%authorProfileURL%/g, question.answers[i].author.profile);


### PR DESCRIPTION
# Description

Fixes missing %date% template variables in StackExchange answer templates.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content)

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `npm run lint`.
- [ ] My change requires an update of README.md
- [ ] I have updated the README.md
