### PR TITLE
cut off note title to fit max file path

### DIFF
--- a/src/helpers/fileutils.ts
+++ b/src/helpers/fileutils.ts
@@ -1,5 +1,6 @@
 import path from 'path';
-import { normalizePath } from 'obsidian';
+import {FileSystemAdapter, normalizePath} from 'obsidian';
+import ReadItLaterPlugin from "../main";
 
 export function isValidUrl(url: string): boolean {
     try {
@@ -23,4 +24,20 @@ export function pathJoin(dir: string, subpath: string): string {
     const result = path.join(dir, subpath);
     // it seems that obsidian do not understand paths with backslashes in Windows, so turn them into forward slashes
     return normalizePath(result.replace(/\\/g, '/'));
+}
+
+export function clampFilePath(filePath: string, plugin: ReadItLaterPlugin): string {
+    if(!(plugin.app.vault.adapter instanceof FileSystemAdapter))
+        return filePath;
+    let fullPath = plugin.app.vault.adapter.getFullPath(filePath);
+    let maxFilePath = parseInt(plugin.settings.maxFilePathLength);
+    
+    let exceedingCharacterCount = 0;
+    if(maxFilePath > 0)
+        exceedingCharacterCount = fullPath.length - maxFilePath;
+
+    const noteSuffix = plugin.settings.maxFilePathExceededSuffix + ".md";
+    if(exceedingCharacterCount > 0)
+        filePath = filePath.substring(0, filePath.length-exceedingCharacterCount-noteSuffix.length)+noteSuffix;
+    return filePath;
 }

--- a/src/helpers/fileutils.ts
+++ b/src/helpers/fileutils.ts
@@ -1,6 +1,6 @@
 import path from 'path';
-import {FileSystemAdapter, normalizePath} from 'obsidian';
-import ReadItLaterPlugin from "../main";
+import { FileSystemAdapter, normalizePath } from 'obsidian';
+import ReadItLaterPlugin from '../main';
 
 export function isValidUrl(url: string): boolean {
     try {
@@ -27,17 +27,15 @@ export function pathJoin(dir: string, subpath: string): string {
 }
 
 export function clampFilePath(filePath: string, plugin: ReadItLaterPlugin): string {
-    if(!(plugin.app.vault.adapter instanceof FileSystemAdapter))
-        return filePath;
-    let fullPath = plugin.app.vault.adapter.getFullPath(filePath);
-    let maxFilePath = parseInt(plugin.settings.maxFilePathLength);
-    
-    let exceedingCharacterCount = 0;
-    if(maxFilePath > 0)
-        exceedingCharacterCount = fullPath.length - maxFilePath;
+    if (!(plugin.app.vault.adapter instanceof FileSystemAdapter)) return filePath;
+    const fullPath = plugin.app.vault.adapter.getFullPath(filePath);
+    const maxFilePath = parseInt(plugin.settings.maxFilePathLength);
 
-    const noteSuffix = plugin.settings.maxFilePathExceededSuffix + ".md";
-    if(exceedingCharacterCount > 0)
-        filePath = filePath.substring(0, filePath.length-exceedingCharacterCount-noteSuffix.length)+noteSuffix;
+    let exceedingCharacterCount = 0;
+    if (maxFilePath > 0) exceedingCharacterCount = fullPath.length - maxFilePath;
+
+    const noteSuffix = plugin.settings.maxFilePathExceededSuffix + '.md';
+    if (exceedingCharacterCount > 0)
+        filePath = filePath.substring(0, filePath.length - exceedingCharacterCount - noteSuffix.length) + noteSuffix;
     return filePath;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import {Menu, MenuItem, Notice, Plugin, addIcon, normalizePath, FileSystemAdapter} from 'obsidian';
+import { FileSystemAdapter, Menu, MenuItem, Notice, Plugin, addIcon, normalizePath } from 'obsidian';
 import { checkAndCreateFolder, normalizeFilename } from './helpers';
 import { DEFAULT_SETTINGS, ReadItLaterSettings } from './settings';
 import { ReadItLaterSettingsTab } from './views/settings-tab';
@@ -12,7 +12,7 @@ import TextSnippetParser from './parsers/TextSnippetParser';
 import MastodonParser from './parsers/MastodonParser';
 import TikTokParser from './parsers/TikTokParser';
 import ParserCreator from './parsers/ParserCreator';
-import {clampFilePath} from "./helpers/fileutils";
+import { clampFilePath } from './helpers/fileutils';
 
 export default class ReadItLaterPlugin extends Plugin {
     settings: ReadItLaterSettings;
@@ -88,7 +88,7 @@ export default class ReadItLaterPlugin extends Plugin {
     }
 
     async writeFile(fileName: string, content: string): Promise<void> {
-        let noticeSuffix = "";
+        let noticeSuffix = '';
         let filePath;
         fileName = normalizeFilename(fileName);
         await checkAndCreateFolder(this.app.vault, this.settings.inboxDir);
@@ -98,12 +98,11 @@ export default class ReadItLaterPlugin extends Plugin {
         } else {
             filePath = normalizePath(`/${fileName}`);
         }
-        
-        let oldPath = filePath;
+
+        const oldPath = filePath;
         filePath = clampFilePath(filePath, this);
-        if(filePath != oldPath)
-            noticeSuffix += "\n\n(Title was cut off to fit max file path)"
-        
+        if (filePath != oldPath) noticeSuffix += '\n\n(Title was cut off to fit max file path)';
+
         if (await this.app.vault.adapter.exists(filePath)) {
             new Notice(`${fileName} already exists!`);
         } else {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -29,6 +29,8 @@ export interface ReadItLaterSettings {
     downloadImagesInArticleDir: boolean;
     dateTitleFmt: string;
     dateContentFmt: string;
+    maxFilePathLength: string;
+    maxFilePathExceededSuffix: string;
     downloadMastodonMediaAttachments: boolean;
     downloadMastodonMediaAttachmentsInDir: boolean;
     saveMastodonReplies: boolean;
@@ -77,6 +79,8 @@ export const DEFAULT_SETTINGS: ReadItLaterSettings = {
     downloadImagesInArticleDir: false,
     dateTitleFmt: 'YYYY-MM-DD HH-mm-ss',
     dateContentFmt: 'YYYY-MM-DD',
+    maxFilePathLength: '247',
+    maxFilePathExceededSuffix: '~',
     downloadMastodonMediaAttachments: true,
     downloadMastodonMediaAttachmentsInDir: false,
     saveMastodonReplies: false,

--- a/src/views/settings-tab.ts
+++ b/src/views/settings-tab.ts
@@ -102,10 +102,12 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
                         await this.plugin.saveSettings();
                     }),
             );
-        
+
         new Setting(containerEl)
             .setName('Maximum file path length')
-            .setDesc('The maximum path length in Windows is 247 by default. Only increase this if you actually extended it.')
+            .setDesc(
+                'The maximum path length in Windows is 247 by default. Only increase this if you actually extended it.',
+            )
             .addText((text) =>
                 text
                     .setPlaceholder(DEFAULT_SETTINGS.maxFilePathLength)
@@ -121,7 +123,9 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
             .addText((text) =>
                 text
                     .setPlaceholder(DEFAULT_SETTINGS.maxFilePathExceededSuffix)
-                    .setValue(this.plugin.settings.maxFilePathExceededSuffix || DEFAULT_SETTINGS.maxFilePathExceededSuffix)
+                    .setValue(
+                        this.plugin.settings.maxFilePathExceededSuffix || DEFAULT_SETTINGS.maxFilePathExceededSuffix,
+                    )
                     .onChange(async (value) => {
                         this.plugin.settings.maxFilePathExceededSuffix = value;
                         await this.plugin.saveSettings();
@@ -129,7 +133,7 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
             );
 
         containerEl.createEl('h1', { text: 'Note Templates' });
-        
+
         containerEl.createEl('h2', { text: 'YouTube' });
 
         new Setting(containerEl)

--- a/src/views/settings-tab.ts
+++ b/src/views/settings-tab.ts
@@ -15,7 +15,7 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
 
         containerEl.empty();
 
-        containerEl.createEl('h2', { text: 'General' });
+        containerEl.createEl('h1', { text: 'General' });
 
         new Setting(containerEl)
             .setName('Inbox dir')
@@ -102,7 +102,34 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
                         await this.plugin.saveSettings();
                     }),
             );
+        
+        new Setting(containerEl)
+            .setName('Maximum file path length')
+            .setDesc('The maximum path length in Windows is 247 by default. Only increase this if you actually extended it.')
+            .addText((text) =>
+                text
+                    .setPlaceholder(DEFAULT_SETTINGS.maxFilePathLength)
+                    .setValue(this.plugin.settings.maxFilePathLength || DEFAULT_SETTINGS.maxFilePathLength)
+                    .onChange(async (value) => {
+                        this.plugin.settings.maxFilePathLength = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
+        new Setting(containerEl)
+            .setName('Maximum file path exceeded suffix')
+            .setDesc('The text that will be used to cut off titles that exceed the maximum file path.')
+            .addText((text) =>
+                text
+                    .setPlaceholder(DEFAULT_SETTINGS.maxFilePathExceededSuffix)
+                    .setValue(this.plugin.settings.maxFilePathExceededSuffix || DEFAULT_SETTINGS.maxFilePathExceededSuffix)
+                    .onChange(async (value) => {
+                        this.plugin.settings.maxFilePathExceededSuffix = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
+        containerEl.createEl('h1', { text: 'Note Templates' });
+        
         containerEl.createEl('h2', { text: 'YouTube' });
 
         new Setting(containerEl)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
Added two config values to cut off titles that are too long: a maximum length and a cut-off string

<!--- Describe your changes in detail -->

## Motivation and Context
Fixes https://github.com/DominikPieper/obsidian-ReadItLater/issues/160

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Saving links with different lengths and playing with the config values

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content)

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `npm run lint`.
- [x] My change requires an update of README.md
- [ ] I have updated the README.md
