### PR TITLE
fix: YouTube Schema.org parsing

### DIFF
--- a/src/parsers/YoutubeParser.ts
+++ b/src/parsers/YoutubeParser.ts
@@ -138,7 +138,12 @@ class YoutubeParser extends Parser {
             });
 
             const videoHTML = new DOMParser().parseFromString(response, 'text/html');
-            const videoSchemaElement = videoHTML.querySelector('[itemtype="http://schema.org/VideoObject"]');
+            const videoSchemaElement = videoHTML.querySelector('[itemtype*="http://schema.org/VideoObject"]');
+
+            if (videoSchemaElement === null) {
+                throw new Error('Unable to find Schema.org element in HTML.');
+            }
+
             const videoId = videoSchemaElement?.querySelector('[itemprop="identifier"]')?.getAttribute('content') ?? '';
             const personSchemaElement = videoSchemaElement.querySelector('[itemtype="http://schema.org/Person"]');
 
@@ -146,7 +151,7 @@ class YoutubeParser extends Parser {
                 id: videoId,
                 url: url,
                 title: videoSchemaElement?.querySelector('[itemprop="name"]')?.getAttribute('content') ?? '',
-                description: '',
+                description: videoSchemaElement?.querySelector('[itemprop="description"]')?.getAttribute('content') ?? '',
                 thumbnail: videoHTML.querySelector('meta[property="og:image"]')?.getAttribute('content') ?? '',
                 player: this.getEmbedPlayer(videoId),
                 duration: 0,


### PR DESCRIPTION
# Description

Fix parsing of Schema.org data from HTML markup.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content)

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `npm run lint`.
- [ ] My change requires an update of README.md
- [ ] I have updated the README.md
