### PR TITLE
feat: Add setting to open new note in new tab

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -101,8 +101,8 @@ export default class ReadItLaterPlugin extends Plugin {
             new Notice(`${fileName} already exists!`);
         } else {
             const newFile = await this.app.vault.create(filePath, content);
-            if (this.settings.openNewNote) {
-                this.app.workspace.getLeaf(false).openFile(newFile);
+            if (this.settings.openNewNote || this.settings.openNewNoteInNewTab) {
+                this.app.workspace.getLeaf(this.settings.openNewNoteInNewTab ? 'tab' : false).openFile(newFile);
             }
             new Notice(`${fileName} created successful`);
         }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2,6 +2,7 @@ export interface ReadItLaterSettings {
     inboxDir: string;
     assetsDir: string;
     openNewNote: boolean;
+    openNewNoteInNewTab: boolean;
     youtubeNoteTitle: string;
     youtubeNote: string;
     youtubeEmbedWidth: string;
@@ -50,6 +51,7 @@ export const DEFAULT_SETTINGS: ReadItLaterSettings = {
     inboxDir: 'ReadItLater Inbox',
     assetsDir: 'ReadItLater Inbox/assets',
     openNewNote: false,
+    openNewNoteInNewTab: false,
     youtubeNoteTitle: 'Youtube - %title%',
     youtubeNote: '[[ReadItLater]] [[Youtube]]\n\n# [%videoTitle%](%videoURL%)\n\n%videoPlayer%',
     youtubeEmbedWidth: '560',

--- a/src/views/settings-tab.ts
+++ b/src/views/settings-tab.ts
@@ -48,14 +48,34 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
             );
 
         new Setting(containerEl)
-            .setName('Open new note')
+            .setName('Open new note in current workspace')
             .setDesc('If enabled, new note will open in current workspace')
             .addToggle((toggle) =>
                 toggle
                     .setValue(this.plugin.settings.openNewNote || DEFAULT_SETTINGS.openNewNote)
                     .onChange(async (value) => {
                         this.plugin.settings.openNewNote = value;
+                        if (value === true) {
+                            this.plugin.settings.openNewNoteInNewTab = false;
+                        }
                         await this.plugin.saveSettings();
+                        this.display();
+                    }),
+            );
+
+        new Setting(containerEl)
+            .setName('Open new note in new tab')
+            .setDesc('If enabled, new note will open in new tab')
+            .addToggle((toggle) =>
+                toggle
+                    .setValue(this.plugin.settings.openNewNoteInNewTab || DEFAULT_SETTINGS.openNewNoteInNewTab)
+                    .onChange(async (value) => {
+                        this.plugin.settings.openNewNoteInNewTab = value;
+                        if (value === true) {
+                            this.plugin.settings.openNewNote = false;
+                        }
+                        await this.plugin.saveSettings();
+                        this.display();
                     }),
             );
 


### PR DESCRIPTION
# Description

This PR adds new setting to open new notes in new tab instead of current workspace.

## Motivation and Context

User request in https://github.com/DominikPieper/obsidian-ReadItLater/discussions/169

## How has this been tested?

All possible settings combination.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content)

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `npm run lint`.
- [ ] My change requires an update of README.md
- [ ] I have updated the README.md
