### PR TITLE
feat: github parser

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ import MastodonParser from './parsers/MastodonParser';
 import TikTokParser from './parsers/TikTokParser';
 import ParserCreator from './parsers/ParserCreator';
 import { HTTPS_PROTOCOL, HTTP_PROTOCOL } from './constants/urlProtocols';
+import GithubParser from './parsers/GithubParser';
 
 export default class ReadItLaterPlugin extends Plugin {
     settings: ReadItLaterSettings;
@@ -29,6 +30,7 @@ export default class ReadItLaterPlugin extends Plugin {
             new StackExchangeParser(this.app, this.settings),
             new MastodonParser(this.app, this.settings),
             new TikTokParser(this.app, this.settings),
+            new GithubParser(this.app, this.settings),
             new WebsiteParser(this.app, this.settings),
             new TextSnippetParser(this.app, this.settings),
         ]);

--- a/src/parsers/GithubParser.ts
+++ b/src/parsers/GithubParser.ts
@@ -1,0 +1,24 @@
+import { Note } from './Note';
+import WebsiteParser from './WebsiteParser';
+
+export default class GithubParser extends WebsiteParser {
+    private PATTERN = /^https?:\/\/(?:www\.)?github\.com\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+)$/;
+
+    test(url: string): boolean {
+        return this.isValidUrl(url) && this.PATTERN.test(url);
+    }
+
+    async prepareNote(url: string): Promise<Note> {
+        const originUrl = new URL(url);
+        const document = await this.getDocument(originUrl);
+
+        // Extract readme content
+        const readme = document.querySelector('article.markdown-body');
+        // Remove anchor elements causing to show empty links
+        readme.querySelectorAll('[aria-label^="Permalink:"]').forEach((anchorElement) => anchorElement.remove());
+
+        document.querySelector('body').innerHTML = readme.outerHTML;
+
+        return this.makeNote(document, originUrl);
+    }
+}

--- a/src/parsers/StackExchangeParser.ts
+++ b/src/parsers/StackExchangeParser.ts
@@ -52,8 +52,7 @@ class StackExchangeParser extends Parser {
                   .replace(/%answerContent%/g, () => question.topAnswer.content)
                   .replace(/%authorName%/g, () => question.topAnswer.author.name)
                   .replace(/%authorProfileURL%/g, () => question.topAnswer.author.profile)
-                  
-                  : '';
+            : '';
         let answers = '';
         for (let i = 0; i < question.answers.length; i++) {
             const answer = this.settings.stackExchangeAnswer
@@ -79,7 +78,7 @@ class StackExchangeParser extends Parser {
             : this.settings.assetsDir;
 
         if (this.settings.downloadStackExchangeAssets && Platform.isDesktop) {
-            content = await replaceImages(app, content, assetsDir);
+            content = await replaceImages(this.app, content, assetsDir);
         }
 
         const fileName = `${fileNameTemplate}.md`;


### PR DESCRIPTION
# Description

Although parsing of Github page was enhanced in #170 some repositories with shorter README were not parsed correctly. There was also empty link after heading. These issues was fixed in new Github parser.

## How has this been tested?

Saving multiple repositories such as:
- https://github.com/obsidian-tasks-group/obsidian-tasks
- https://github.com/laravel/laravel
- https://github.com/okta/okta-sdk-dotnet

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content)

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `npm run lint`.
- [ ] My change requires an update of README.md
- [ ] I have updated the README.md
