### PR TITLE
feat: inbox directories template variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,15 @@ Save the web with ReadItLater plugin for Obsidian. Archive web pages for reading
 
 ReadItLater can do a lot more than converting web pages to markdown. For every content type there is specific template with carefully selected variables to ease up your archiving process.
 
-To add something to your vault just click the `ReadItLater: Save clipboard` ribbon or run the `ReadItLater: Save clipboard` command. New note will be created in folder configured in plugin settings.
+To add something to your Vault just click the `ReadItLater: Save clipboard` ribbon or run the `ReadItLater: Save clipboard` command. New note will be created in folder configured in plugin settings.
+
+### What makes ReadItLater plugin great?
+
+- Simple, but powerful template engine
+- Carefully selected predefined template variables to straightforward archiving process
+- Compatibility with Obsidian iOS and Android apps
+- Downloading images from articles to your Vault
+- Batch processing of URLs list
 
 ## Template engine
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,16 @@ outputs: HELLO WORLD
 ```
 </details>
 
+## Inbox and Assets directories
+
+You can use template variables in `Inbox dir` and `Assets dir` settings to better distribute content in your Vault.
+
+| Directory template variable | Description                                        |
+| --------------------------- | -------------------------------------------------- |
+| date                        | Current date in format from plguin settins         |
+| fileName                    | Filename of new note                               |
+| contentType                 | Slug of detected content type from plugin settings |
+
 ## Content Types
 
 Structure of note content is determined by URL. Currenty plugin supports saving content of websites and embedding content from multiple services. Each content type has title and note template with replacable variables, which can be edited in plugin settings.

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 	"name": "ReadItLater",
 	"version": "0.7.0",
 	"minAppVersion": "1.6.2",
-	"description": "Saves the clipboard to a new note.",
+	"description": "Archive web pages for reading later, referencing in your second brain or for other flexible use case Obsidian provides.",
 	"author": "Dominik Pieper",
 	"authorUrl": "https://github.com/DominikPieper",
 	"isDesktopOnly": false

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "obsidian-ReadItLater",
   "version": "0.7.0",
-  "description": "Plugin for Obsidian to collect interesting information from your clipboard into your vault",
+  "description": "Archive web pages for reading later, referencing in your second brain or for other flexible use case Obsidian provides.",
   "main": "main.js",
   "scripts": {
     "dev": "node esbuild.config.mjs development",

--- a/src/parsers/BilibiliParser.ts
+++ b/src/parsers/BilibiliParser.ts
@@ -24,19 +24,20 @@ class BilibiliParser extends Parser {
     }
 
     async prepareNote(url: string): Promise<Note> {
-        const data = await this.getNoteData(url);
+        const createdAt = new Date();
+        const data = await this.getNoteData(url, createdAt);
 
         const content = this.templateEngine.render(this.settings.bilibiliNote, data);
 
         const fileNameTemplate = this.templateEngine.render(this.settings.bilibiliNoteTitle, {
             title: data.videoTitle,
-            date: this.getFormattedDateForFilename(),
+            date: this.getFormattedDateForFilename(createdAt),
         });
 
-        return new Note(`${fileNameTemplate}.md`, content);
+        return new Note(fileNameTemplate, 'md', content, this.settings.bilibiliContentTypeSlug, createdAt);
     }
 
-    private async getNoteData(url: string): Promise<BilibiliNoteData> {
+    private async getNoteData(url: string, createdAt: Date): Promise<BilibiliNoteData> {
         const response = await request({
             method: 'GET',
             url,
@@ -49,7 +50,7 @@ class BilibiliParser extends Parser {
         const videoId = this.PATTERN.exec(url)[3] ?? '';
 
         return {
-            date: this.getFormattedDateForContent(),
+            date: this.getFormattedDateForContent(createdAt),
             videoId: videoId,
             videoTitle: videoHTML.querySelector("[property~='og:title']").getAttribute('content') ?? '',
             videoURL: url,

--- a/src/parsers/Note.ts
+++ b/src/parsers/Note.ts
@@ -1,9 +1,17 @@
-export class Note {
-    public readonly fileName: string;
-    public readonly content: string;
+import { normalizeFilename } from 'src/helpers';
 
-    constructor(fileName: string, content: string) {
-        this.fileName = fileName;
-        this.content = content;
+export class Note {
+    constructor(
+        public readonly fileName: string,
+        public readonly fileExtension: string,
+        public readonly content: string,
+        public readonly contentType: string,
+        public readonly createdAt: Date,
+    ) {
+        this.fileName = normalizeFilename(this.fileName);
+    }
+
+    public getFullFilename(): string {
+        return `${this.fileName}.${this.fileExtension}`;
     }
 }

--- a/src/parsers/Parser.ts
+++ b/src/parsers/Parser.ts
@@ -1,6 +1,6 @@
 import { App } from 'obsidian';
 import TemplateEngine from 'src/template/TemplateEngine';
-import { formatCurrentDate, isValidUrl } from '../helpers';
+import { formatDate, isValidUrl } from '../helpers';
 import { ReadItLaterSettings } from '../settings';
 import { Note } from './Note';
 
@@ -23,11 +23,11 @@ export abstract class Parser {
         return isValidUrl(url);
     }
 
-    protected getFormattedDateForFilename(): string {
-        return formatCurrentDate(this.settings.dateTitleFmt);
+    protected getFormattedDateForFilename(date: Date | string): string {
+        return formatDate(date, this.settings.dateTitleFmt);
     }
 
-    protected getFormattedDateForContent(): string {
-        return formatCurrentDate(this.settings.dateContentFmt);
+    protected getFormattedDateForContent(date: Date | string): string {
+        return formatDate(date, this.settings.dateContentFmt);
     }
 }

--- a/src/parsers/StackExchangeParser.ts
+++ b/src/parsers/StackExchangeParser.ts
@@ -58,9 +58,10 @@ class StackExchangeParser extends Parser {
         const document = new DOMParser().parseFromString(response, 'text/html');
         const question = await this.parseDocument(document);
 
-        const fileNameTemplate = this.settings.stackExchangeNoteTitle
-            .replace(/%title%/g, () => question.title)
-            .replace(/%date%/g, this.getFormattedDateForFilename(createdAt));
+        const fileNameTemplate = this.templateEngine.render(this.settings.stackExchangeNoteTitle, {
+            title: question.title,
+            date: this.getFormattedDateForFilename(createdAt)
+        });
 
         let assetsDir;
         if (this.settings.downloadStackExchangeAssetsInDir) {
@@ -95,8 +96,8 @@ class StackExchangeParser extends Parser {
             ? this.templateEngine.render(this.settings.stackExchangeAnswer, {
                   date: this.getFormattedDateForContent(createdAt),
                   answerContent: question.topAnswer.content,
-                  authorName: question.author.name,
-                  authorProfileURL: question.author.profile,
+                  authorName: question.topAnswer.author.name,
+                  authorProfileURL: question.topAnswer.author.profile,
               })
             : '';
 

--- a/src/parsers/StackExchangeParser.ts
+++ b/src/parsers/StackExchangeParser.ts
@@ -60,7 +60,7 @@ class StackExchangeParser extends Parser {
 
         const fileNameTemplate = this.templateEngine.render(this.settings.stackExchangeNoteTitle, {
             title: question.title,
-            date: this.getFormattedDateForFilename(createdAt)
+            date: this.getFormattedDateForFilename(createdAt),
         });
 
         let assetsDir;

--- a/src/parsers/TextSnippetParser.ts
+++ b/src/parsers/TextSnippetParser.ts
@@ -15,14 +15,15 @@ class TextSnippetParser extends Parser {
 
     async prepareNote(text: string): Promise<Note> {
         const createdAt = new Date();
-        const fileNameTemplate = this.settings.textSnippetNoteTitle.replace(
-            /%date%/g,
-            this.getFormattedDateForFilename(createdAt),
-        );
 
-        const content = this.settings.textSnippetNote
-            .replace(/%content%/g, () => text)
-            .replace(/%date%/g, this.getFormattedDateForContent(createdAt));
+        const fileNameTemplate = this.templateEngine.render(this.settings.textSnippetNoteTitle, {
+            date: this.getFormattedDateForFilename(createdAt)
+        });
+
+        const content = this.templateEngine.render(this.settings.textSnippetNote, {
+            content: text,
+            date: this.getFormattedDateForContent(createdAt)
+        });
         return new Note(fileNameTemplate, 'md', content, this.settings.textSnippetContentType, createdAt);
     }
 }

--- a/src/parsers/TextSnippetParser.ts
+++ b/src/parsers/TextSnippetParser.ts
@@ -17,12 +17,12 @@ class TextSnippetParser extends Parser {
         const createdAt = new Date();
 
         const fileNameTemplate = this.templateEngine.render(this.settings.textSnippetNoteTitle, {
-            date: this.getFormattedDateForFilename(createdAt)
+            date: this.getFormattedDateForFilename(createdAt),
         });
 
         const content = this.templateEngine.render(this.settings.textSnippetNote, {
             content: text,
-            date: this.getFormattedDateForContent(createdAt)
+            date: this.getFormattedDateForContent(createdAt),
         });
         return new Note(fileNameTemplate, 'md', content, this.settings.textSnippetContentType, createdAt);
     }

--- a/src/parsers/TextSnippetParser.ts
+++ b/src/parsers/TextSnippetParser.ts
@@ -14,16 +14,16 @@ class TextSnippetParser extends Parser {
     }
 
     async prepareNote(text: string): Promise<Note> {
+        const createdAt = new Date();
         const fileNameTemplate = this.settings.textSnippetNoteTitle.replace(
             /%date%/g,
-            this.getFormattedDateForFilename(),
+            this.getFormattedDateForFilename(createdAt),
         );
-        const fileName = `${fileNameTemplate}.md`;
 
         const content = this.settings.textSnippetNote
             .replace(/%content%/g, () => text)
-            .replace(/%date%/g, this.getFormattedDateForContent());
-        return new Note(fileName, content);
+            .replace(/%date%/g, this.getFormattedDateForContent(createdAt));
+        return new Note(fileNameTemplate, 'md', content, this.settings.textSnippetContentType, createdAt);
     }
 }
 

--- a/src/parsers/TikTokParser.ts
+++ b/src/parsers/TikTokParser.ts
@@ -26,19 +26,20 @@ class TikTokParser extends Parser {
     }
 
     async prepareNote(clipboardContent: string): Promise<Note> {
-        const data = await this.parseHtml(clipboardContent);
+        const createdAt = new Date();
+        const data = await this.parseHtml(clipboardContent, createdAt);
 
         const content = this.templateEngine.render(this.settings.tikTokNote, data);
 
         const fileNameTemplate = this.templateEngine.render(this.settings.tikTokNoteTitle, {
             authorName: data.authorName,
-            date: this.getFormattedDateForFilename(),
+            date: this.getFormattedDateForFilename(createdAt),
         });
 
-        return new Note(`${fileNameTemplate}.md`, content);
+        return new Note(fileNameTemplate, 'md', content, this.settings.tikTokContentTypeSlug, createdAt);
     }
 
-    private async parseHtml(url: string): Promise<TiktokNoteData> {
+    private async parseHtml(url: string, createdAt: Date): Promise<TiktokNoteData> {
         const response = await request({
             method: 'GET',
             url,
@@ -52,7 +53,7 @@ class TikTokParser extends Parser {
         const videoRegexExec = this.PATTERN.exec(url);
 
         return {
-            date: this.getFormattedDateForContent(),
+            date: this.getFormattedDateForContent(createdAt),
             videoId: videoRegexExec[4],
             videoURL: videoHTML.querySelector('meta[property="og:url"]')?.getAttribute('content') ?? url,
             videoDescription: videoHTML.querySelector('meta[property="og:description"]')?.getAttribute('content') ?? '',

--- a/src/parsers/TwitterParser.ts
+++ b/src/parsers/TwitterParser.ts
@@ -25,25 +25,26 @@ class TwitterParser extends Parser {
     }
 
     async prepareNote(url: string): Promise<Note> {
+        const createdAt = new Date();
         const twitterUrl = new URL(url);
 
         if (twitterUrl.hostname === 'x.com') {
             twitterUrl.hostname = 'twitter.com';
         }
 
-        const data = await this.getTweetNoteData(twitterUrl);
+        const data = await this.getTweetNoteData(twitterUrl, createdAt);
 
         const content = this.templateEngine.render(this.settings.twitterNote, data);
 
         const fileNameTemplate = this.templateEngine.render(this.settings.twitterNoteTitle, {
             tweetAuthorName: data.tweetAuthorName,
-            date: this.getFormattedDateForFilename(),
+            date: this.getFormattedDateForFilename(createdAt),
         });
 
-        return new Note(`${fileNameTemplate}.md`, content);
+        return new Note(fileNameTemplate, 'md', content, this.settings.twitterContentTypeSlug, createdAt);
     }
 
-    private async getTweetNoteData(url: URL): Promise<TweetNoteData> {
+    private async getTweetNoteData(url: URL, createdAt: Date): Promise<TweetNoteData> {
         const response = JSON.parse(
             await request({
                 method: 'GET',
@@ -55,7 +56,7 @@ class TwitterParser extends Parser {
         const content = await parseHtmlContent(response.html);
 
         return {
-            date: this.getFormattedDateForContent(),
+            date: this.getFormattedDateForContent(createdAt),
             tweetAuthorName: response.author_name,
             tweetURL: response.url,
             tweetContent: content,

--- a/src/parsers/VimeoParser.ts
+++ b/src/parsers/VimeoParser.ts
@@ -42,19 +42,20 @@ class VimeoParser extends Parser {
     }
 
     async prepareNote(clipboardContent: string): Promise<Note> {
-        const data = await this.parseSchema(clipboardContent);
+        const createdAt = new Date();
+        const data = await this.parseSchema(clipboardContent, createdAt);
 
         const content = this.templateEngine.render(this.settings.vimeoNote, data);
 
         const fileNameTemplate = this.templateEngine.render(this.settings.vimeoNoteTitle, {
             title: data.videoTitle,
-            date: this.getFormattedDateForFilename(),
+            date: this.getFormattedDateForFilename(createdAt),
         });
 
-        return new Note(`${fileNameTemplate}.md`, content);
+        return new Note(fileNameTemplate, 'md', content, this.settings.vimeoContentTypeSlug, createdAt);
     }
 
-    private async parseSchema(url: string): Promise<VimeoNoteData> {
+    private async parseSchema(url: string, createdAt: Date): Promise<VimeoNoteData> {
         const response = await request({
             method: 'GET',
             url,
@@ -71,7 +72,7 @@ class VimeoParser extends Parser {
         const videoIdRegexExec = this.PATTERN.exec(url);
 
         return {
-            date: this.getFormattedDateForContent(),
+            date: this.getFormattedDateForContent(createdAt),
             videoId: videoIdRegexExec.length === 3 ? videoIdRegexExec[2] : '',
             videoURL: videoSchema?.url ?? '',
             videoTitle: videoSchema?.name ?? '',

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -7,27 +7,35 @@ export interface ReadItLaterSettings {
     batchProcess: boolean;
     batchProcessDelimiter: Delimiter;
     openNewNoteInNewTab: boolean;
+    youtubeContentTypeSlug: string;
     youtubeNoteTitle: string;
     youtubeNote: string;
     youtubeEmbedWidth: string;
     youtubeEmbedHeight: string;
     youtubeUsePrivacyEnhancedEmbed: boolean;
+    vimeoContentTypeSlug: string;
     vimeoNoteTitle: string;
     vimeoNote: string;
     vimeoEmbedWidth: string;
     vimeoEmbedHeight: string;
+    bilibiliContentTypeSlug: string;
     bilibiliNoteTitle: string;
     bilibiliNote: string;
     bilibiliEmbedWidth: string;
     bilibiliEmbedHeight: string;
+    twitterContentTypeSlug: string;
     twitterNoteTitle: string;
     twitterNote: string;
+    parseableArticleContentType: string;
     parseableArticleNoteTitle: string;
     parsableArticleNote: string;
+    notParseableArticleContentType: string;
     notParseableArticleNoteTitle: string;
     notParsableArticleNote: string;
+    textSnippetContentType: string;
     textSnippetNoteTitle: string;
     textSnippetNote: string;
+    mastodonContentTypeSlug: string;
     mastodonNoteTitle: string;
     mastodonNote: string;
     downloadImages: boolean;
@@ -38,12 +46,14 @@ export interface ReadItLaterSettings {
     downloadMastodonMediaAttachmentsInDir: boolean;
     saveMastodonReplies: boolean;
     mastodonReply: string;
+    stackExchangeContentType: string;
     stackExchangeNoteTitle: string;
     stackExchangeNote: string;
     stackExchangeAnswer: string;
     downloadStackExchangeAssets: boolean;
     downloadStackExchangeAssetsInDir: boolean;
     youtubeApiKey: string;
+    tikTokContentTypeSlug: string;
     tikTokNoteTitle: string;
     tikTokNote: string;
     tikTokEmbedWidth: string;
@@ -58,28 +68,36 @@ export const DEFAULT_SETTINGS: ReadItLaterSettings = {
     batchProcess: false,
     batchProcessDelimiter: Delimiter.NewLine,
     openNewNoteInNewTab: false,
+    youtubeContentTypeSlug: 'youtube',
     youtubeNoteTitle: 'Youtube - {{ title }}',
     youtubeNote: '[[ReadItLater]] [[Youtube]]\n\n# [{{ videoTitle }}]({{ videoURL }})\n\n{{ videoPlayer }}',
     youtubeEmbedWidth: '560',
     youtubeEmbedHeight: '315',
     youtubeUsePrivacyEnhancedEmbed: true,
+    vimeoContentTypeSlug: 'vimeo',
     vimeoNoteTitle: 'Vimeo - {{ title }}',
     vimeoNote: '[[ReadItLater]] [[Vimeo]]\n\n# [{{ videoTitle }}]({{ videoURL }})\n\n{{ videoPlayer }}',
     vimeoEmbedWidth: '560',
     vimeoEmbedHeight: '315',
+    bilibiliContentTypeSlug: 'bilibili',
     bilibiliNoteTitle: 'Bilibili - {{ title }}',
     bilibiliNote: '[[ReadItLater]] [[Bilibili]]\n\n# [{{ videoTitle }}]({{ videoURL }})\n\n{{ videoPlayer }}',
     bilibiliEmbedWidth: '560',
     bilibiliEmbedHeight: '315',
+    twitterContentTypeSlug: 'xcom',
     twitterNoteTitle: 'Tweet from {{ tweetAuthorName }} ({{ date }})',
     twitterNote: '[[ReadItLater]] [[Tweet]]\n\n# [{{ tweetAuthorName }}]({{ tweetURL }})\n\n{{ tweetContent }}',
+    parseableArticleContentType: 'article',
     parseableArticleNoteTitle: '{{ title }}',
     parsableArticleNote:
         '[[ReadItLater]] [[Article]]\n\n# [{{ articleTitle }}]({{ articleURL }})\n\n{{ articleContent }}',
+    notParseableArticleContentType: 'article',
     notParseableArticleNoteTitle: 'Article {{ date }}',
     notParsableArticleNote: '[[ReadItLater]] [[Article]]\n\n[{{ articleURL }}]({{ articleURL }})',
+    textSnippetContentType: 'textsnippet',
     textSnippetNoteTitle: 'Note {{ date }}',
     textSnippetNote: '[[ReadItLater]] [[Textsnippet]]\n\n{{ content }}',
+    mastodonContentTypeSlug: 'mastodon',
     mastodonNoteTitle: 'Toot from {{ tootAuthorName }} ({{ date }})',
     mastodonNote: '[[ReadItLater]] [[Toot]]\n\n# [{{ tootAuthorName }}]({{ tootURL }})\n\n> {{ tootContent }}',
     downloadImages: true,
@@ -90,6 +108,7 @@ export const DEFAULT_SETTINGS: ReadItLaterSettings = {
     downloadMastodonMediaAttachmentsInDir: false,
     saveMastodonReplies: false,
     mastodonReply: '[{{ tootAuthorName }}]({{ tootURL }})\n\n> {{ tootContent }}',
+    stackExchangeContentType: 'stackexchange',
     stackExchangeNoteTitle: '{{ title }}',
     stackExchangeNote:
         '[[ReadItLater]] [[StackExchange]]\n\n# [{{ questionTitle }}]({{ questionURL }})\n\nAuthor: [{{ authorName }}]({{ authorProfileURL }})\n\n{{ questionContent }}\n\n***\n\n{{ topAnswer }}\n\n{{ answers }}',
@@ -97,6 +116,7 @@ export const DEFAULT_SETTINGS: ReadItLaterSettings = {
     downloadStackExchangeAssets: true,
     downloadStackExchangeAssetsInDir: false,
     youtubeApiKey: '',
+    tikTokContentTypeSlug: 'tiktok',
     tikTokNoteTitle: 'TikTok from {{ authorName }} ({{ date }})',
     tikTokNote:
         '[[ReadItLater]] [[TikTok]]\n\n{{ videoDescription }}\n\n[{{ videoURL }}]({{ videoURL }})\n\n{{ videoPlayer }}',

--- a/src/template/TemplateEngine.ts
+++ b/src/template/TemplateEngine.ts
@@ -8,7 +8,8 @@ interface Modifiers {
     [key: string]: ModifierFunction;
 }
 
-const stringableTypes: string[] = ['string', 'number', 'bigint', 'symbol'];
+export const stringableTypes: string[] = ['string', 'number', 'bigint', 'symbol'];
+export const variableRegex = /{{(.*?)}}/g;
 
 export default class TemplateEngine {
     private modifiers: Modifiers;
@@ -118,8 +119,6 @@ export default class TemplateEngine {
     }
 
     private processVariables(template: string, data: TemplateData): string {
-        const variableRegex = /{{(.*?)}}/g;
-
         return template.replace(variableRegex, (match: string, content: string) => {
             try {
                 const [key, ...modifiers] = content.split('|').map((item) => item.trim());

--- a/src/views/settings-tab.ts
+++ b/src/views/settings-tab.ts
@@ -25,8 +25,12 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
             )
             .addText((text) =>
                 text
-                    .setPlaceholder('Defaults to root')
-                    .setValue(this.plugin.settings.inboxDir || DEFAULT_SETTINGS.inboxDir)
+                    .setPlaceholder('Defaults to vault root directory')
+                    .setValue(
+                        typeof this.plugin.settings.inboxDir === 'undefined'
+                            ? DEFAULT_SETTINGS.inboxDir
+                            : this.plugin.settings.inboxDir,
+                    )
                     .onChange(async (value) => {
                         this.plugin.settings.inboxDir = value;
                         await this.plugin.saveSettings();
@@ -40,8 +44,12 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
             )
             .addText((text) =>
                 text
-                    .setPlaceholder('Defaults to root')
-                    .setValue(this.plugin.settings.assetsDir || DEFAULT_SETTINGS.inboxDir + '/assets')
+                    .setPlaceholder('Defaults to vault root directory')
+                    .setValue(
+                        typeof this.plugin.settings.assetsDir === 'undefined'
+                            ? DEFAULT_SETTINGS.inboxDir + '/assets'
+                            : this.plugin.settings.assetsDir,
+                    )
                     .onChange(async (value) => {
                         this.plugin.settings.assetsDir = value;
                         await this.plugin.saveSettings();
@@ -113,8 +121,12 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
             .setDesc('Format of the %date% variable. NOTE: do not use symbols forbidden in file names.')
             .addText((text) =>
                 text
-                    .setPlaceholder('Defaults to YYYY-MM-DD HH-mm-ss')
-                    .setValue(this.plugin.settings.dateTitleFmt || DEFAULT_SETTINGS.dateTitleFmt)
+                    .setPlaceholder(`Defaults to ${DEFAULT_SETTINGS.dateTitleFmt}`)
+                    .setValue(
+                        typeof this.plugin.settings.dateTitleFmt === 'undefined'
+                            ? DEFAULT_SETTINGS.dateTitleFmt
+                            : this.plugin.settings.dateTitleFmt,
+                    )
                     .onChange(async (value) => {
                         this.plugin.settings.dateTitleFmt = value;
                         await this.plugin.saveSettings();
@@ -126,8 +138,12 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
             .setDesc('Format of the %date% variable for content')
             .addText((text) =>
                 text
-                    .setPlaceholder('Defaults to YYYY-MM-DD')
-                    .setValue(this.plugin.settings.dateContentFmt || DEFAULT_SETTINGS.dateContentFmt)
+                    .setPlaceholder(`Defaults to ${DEFAULT_SETTINGS.dateContentFmt}`)
+                    .setValue(
+                        typeof this.plugin.settings.dateContentFmt === 'undefined'
+                            ? DEFAULT_SETTINGS.dateContentFmt
+                            : this.plugin.settings.dateContentFmt,
+                    )
                     .onChange(async (value) => {
                         this.plugin.settings.dateContentFmt = value;
                         await this.plugin.saveSettings();
@@ -154,26 +170,49 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
 
         containerEl.createEl('h2', { text: 'YouTube' });
 
-        new Setting(containerEl).setName('Youtube note template title').addText((text) =>
-            text
-                .setPlaceholder('Defaults to %title%')
-                .setValue(this.plugin.settings.youtubeNoteTitle || DEFAULT_SETTINGS.youtubeNoteTitle)
-                .onChange(async (value) => {
-                    this.plugin.settings.youtubeNoteTitle = value;
-                    await this.plugin.saveSettings();
-                }),
-        );
+        new Setting(containerEl)
+            .setName('Youtube content type slug')
+            .setDesc(this.createTemplateVariableReferenceDiv())
+            .addText((text) =>
+                text
+                    .setPlaceholder(`Defaults to ${DEFAULT_SETTINGS.youtubeContentTypeSlug}`)
+                    .setValue(
+                        typeof this.plugin.settings.youtubeContentTypeSlug === 'undefined'
+                            ? DEFAULT_SETTINGS.youtubeContentTypeSlug
+                            : this.plugin.settings.youtubeContentTypeSlug,
+                    )
+                    .onChange(async (value) => {
+                        this.plugin.settings.youtubeContentTypeSlug = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
-        new Setting(containerEl).setName('Youtube note template').addTextArea((textarea) => {
-            textarea
-                .setValue(this.plugin.settings.youtubeNote || DEFAULT_SETTINGS.youtubeNote)
-                .onChange(async (value) => {
-                    this.plugin.settings.youtubeNote = value;
-                    await this.plugin.saveSettings();
-                });
-            textarea.inputEl.rows = 10;
-            textarea.inputEl.cols = 25;
-        });
+        new Setting(containerEl)
+            .setName('Youtube note template title')
+            .setDesc(this.createTemplateVariableReferenceDiv())
+            .addText((text) =>
+                text
+                    .setPlaceholder(`Defaults to ${DEFAULT_SETTINGS.youtubeNoteTitle}`)
+                    .setValue(this.plugin.settings.youtubeNoteTitle || DEFAULT_SETTINGS.youtubeNoteTitle)
+                    .onChange(async (value) => {
+                        this.plugin.settings.youtubeNoteTitle = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
+
+        new Setting(containerEl)
+            .setName('Youtube note template')
+            .setDesc(this.createTemplateVariableReferenceDiv())
+            .addTextArea((textarea) => {
+                textarea
+                    .setValue(this.plugin.settings.youtubeNote || DEFAULT_SETTINGS.youtubeNote)
+                    .onChange(async (value) => {
+                        this.plugin.settings.youtubeNote = value;
+                        await this.plugin.saveSettings();
+                    });
+                textarea.inputEl.rows = 10;
+                textarea.inputEl.cols = 25;
+            });
 
         new Setting(containerEl)
             .setName('Youtube Data API v3 key')
@@ -228,24 +267,49 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
 
         containerEl.createEl('h2', { text: 'Vimeo' });
 
-        new Setting(containerEl).setName('Vimeo note title template').addText((text) =>
-            text
-                .setPlaceholder('Defaults to %title%')
-                .setValue(this.plugin.settings.vimeoNoteTitle || DEFAULT_SETTINGS.vimeoNoteTitle)
-                .onChange(async (value) => {
-                    this.plugin.settings.vimeoNoteTitle = value;
-                    await this.plugin.saveSettings();
-                }),
-        );
+        new Setting(containerEl)
+            .setName('Vimeo content type slug')
+            .setDesc(this.createTemplateVariableReferenceDiv())
+            .addText((text) =>
+                text
+                    .setPlaceholder(`Defaults to ${DEFAULT_SETTINGS.vimeoContentTypeSlug}`)
+                    .setValue(
+                        typeof this.plugin.settings.vimeoContentTypeSlug === 'undefined'
+                            ? DEFAULT_SETTINGS.vimeoContentTypeSlug
+                            : this.plugin.settings.vimeoContentTypeSlug,
+                    )
+                    .onChange(async (value) => {
+                        this.plugin.settings.vimeoContentTypeSlug = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
-        new Setting(containerEl).setName('Vimeo note template').addTextArea((textarea) => {
-            textarea.setValue(this.plugin.settings.vimeoNote || DEFAULT_SETTINGS.vimeoNote).onChange(async (value) => {
-                this.plugin.settings.vimeoNote = value;
-                await this.plugin.saveSettings();
+        new Setting(containerEl)
+            .setName('Vimeo note title template')
+            .setDesc(this.createTemplateVariableReferenceDiv())
+            .addText((text) =>
+                text
+                    .setPlaceholder('Defaults to %title%')
+                    .setValue(this.plugin.settings.vimeoNoteTitle || DEFAULT_SETTINGS.vimeoNoteTitle)
+                    .onChange(async (value) => {
+                        this.plugin.settings.vimeoNoteTitle = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
+
+        new Setting(containerEl)
+            .setName('Vimeo note template')
+            .setDesc(this.createTemplateVariableReferenceDiv())
+            .addTextArea((textarea) => {
+                textarea
+                    .setValue(this.plugin.settings.vimeoNote || DEFAULT_SETTINGS.vimeoNote)
+                    .onChange(async (value) => {
+                        this.plugin.settings.vimeoNote = value;
+                        await this.plugin.saveSettings();
+                    });
+                textarea.inputEl.rows = 10;
+                textarea.inputEl.cols = 25;
             });
-            textarea.inputEl.rows = 10;
-            textarea.inputEl.cols = 25;
-        });
 
         new Setting(containerEl).setName('Vimeo embed player width').addText((text) =>
             text
@@ -270,8 +334,25 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
         containerEl.createEl('h2', { text: 'Bilibili' });
 
         new Setting(containerEl)
+            .setName('Bilibili content type slug')
+            .setDesc(this.createTemplateVariableReferenceDiv())
+            .addText((text) =>
+                text
+                    .setPlaceholder(`Defaults to ${DEFAULT_SETTINGS.bilibiliContentTypeSlug}`)
+                    .setValue(
+                        typeof this.plugin.settings.bilibiliContentTypeSlug === 'undefined'
+                            ? DEFAULT_SETTINGS.bilibiliContentTypeSlug
+                            : this.plugin.settings.bilibiliContentTypeSlug,
+                    )
+                    .onChange(async (value) => {
+                        this.plugin.settings.bilibiliContentTypeSlug = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
+
+        new Setting(containerEl)
             .setName('Bilibili note template title')
-            .setDesc('Available variables: %title%')
+            .setDesc(this.createTemplateVariableReferenceDiv())
             .addText((text) =>
                 text
                     .setPlaceholder('Defaults to %title%')
@@ -282,16 +363,19 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
                     }),
             );
 
-        new Setting(containerEl).setName('Bilibili note template').addTextArea((textarea) => {
-            textarea
-                .setValue(this.plugin.settings.bilibiliNote || DEFAULT_SETTINGS.bilibiliNote)
-                .onChange(async (value) => {
-                    this.plugin.settings.bilibiliNote = value;
-                    await this.plugin.saveSettings();
-                });
-            textarea.inputEl.rows = 10;
-            textarea.inputEl.cols = 25;
-        });
+        new Setting(containerEl)
+            .setName('Bilibili note template')
+            .setDesc(this.createTemplateVariableReferenceDiv())
+            .addTextArea((textarea) => {
+                textarea
+                    .setValue(this.plugin.settings.bilibiliNote || DEFAULT_SETTINGS.bilibiliNote)
+                    .onChange(async (value) => {
+                        this.plugin.settings.bilibiliNote = value;
+                        await this.plugin.saveSettings();
+                    });
+                textarea.inputEl.rows = 10;
+                textarea.inputEl.cols = 25;
+            });
 
         new Setting(containerEl).setName('Bilibili embed player width').addText((text) =>
             text
@@ -315,27 +399,67 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
 
         containerEl.createEl('h2', { text: 'Twitter' });
 
-        new Setting(containerEl).setName('Twitter note template title').addText((text) =>
-            text
-                .setPlaceholder('Defaults to %tweetAuthorName%')
-                .setValue(this.plugin.settings.twitterNoteTitle || DEFAULT_SETTINGS.twitterNoteTitle)
-                .onChange(async (value) => {
-                    this.plugin.settings.twitterNoteTitle = value;
-                    await this.plugin.saveSettings();
-                }),
-        );
-        new Setting(containerEl).setName('Twitter note template').addTextArea((textarea) => {
-            textarea
-                .setValue(this.plugin.settings.twitterNote || DEFAULT_SETTINGS.twitterNote)
-                .onChange(async (value) => {
-                    this.plugin.settings.twitterNote = value;
-                    await this.plugin.saveSettings();
-                });
-            textarea.inputEl.rows = 10;
-            textarea.inputEl.cols = 25;
-        });
+        new Setting(containerEl)
+            .setName('Twitter content type slug')
+            .setDesc(this.createTemplateVariableReferenceDiv())
+            .addText((text) =>
+                text
+                    .setPlaceholder(`Defaults to ${DEFAULT_SETTINGS.twitterContentTypeSlug}`)
+                    .setValue(
+                        typeof this.plugin.settings.twitterContentTypeSlug === 'undefined'
+                            ? DEFAULT_SETTINGS.twitterContentTypeSlug
+                            : this.plugin.settings.twitterContentTypeSlug,
+                    )
+                    .onChange(async (value) => {
+                        this.plugin.settings.twitterContentTypeSlug = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
+
+        new Setting(containerEl)
+            .setName('Twitter note template title')
+            .setDesc(this.createTemplateVariableReferenceDiv())
+            .addText((text) =>
+                text
+                    .setPlaceholder('Defaults to %tweetAuthorName%')
+                    .setValue(this.plugin.settings.twitterNoteTitle || DEFAULT_SETTINGS.twitterNoteTitle)
+                    .onChange(async (value) => {
+                        this.plugin.settings.twitterNoteTitle = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
+        new Setting(containerEl)
+            .setName('Twitter note template')
+            .setDesc(this.createTemplateVariableReferenceDiv())
+            .addTextArea((textarea) => {
+                textarea
+                    .setValue(this.plugin.settings.twitterNote || DEFAULT_SETTINGS.twitterNote)
+                    .onChange(async (value) => {
+                        this.plugin.settings.twitterNote = value;
+                        await this.plugin.saveSettings();
+                    });
+                textarea.inputEl.rows = 10;
+                textarea.inputEl.cols = 25;
+            });
 
         containerEl.createEl('h2', { text: 'Stack Exchange' });
+
+        new Setting(containerEl)
+            .setName('Stack Exchange content type slug')
+            .setDesc(this.createTemplateVariableReferenceDiv())
+            .addText((text) =>
+                text
+                    .setPlaceholder(`Defaults to ${DEFAULT_SETTINGS.stackExchangeContentType}`)
+                    .setValue(
+                        typeof this.plugin.settings.stackExchangeContentType === 'undefined'
+                            ? DEFAULT_SETTINGS.stackExchangeContentType
+                            : this.plugin.settings.stackExchangeContentType,
+                    )
+                    .onChange(async (value) => {
+                        this.plugin.settings.stackExchangeContentType = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
         new Setting(containerEl).setName('Stack Exchange note title template').addText((text) =>
             text
@@ -347,31 +471,39 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
                 }),
         );
 
-        new Setting(containerEl).setName('Stack Exchange question note template').addTextArea((textarea) => {
-            textarea
-                .setValue(this.plugin.settings.stackExchangeNote || DEFAULT_SETTINGS.stackExchangeNote)
-                .onChange(async (value) => {
-                    this.plugin.settings.stackExchangeNote = value;
-                    await this.plugin.saveSettings();
-                });
-            textarea.inputEl.rows = 10;
-            textarea.inputEl.cols = 25;
-        });
+        new Setting(containerEl)
+            .setName('Stack Exchange question note template')
+            .setDesc(this.createTemplateVariableReferenceDiv())
+            .addTextArea((textarea) => {
+                textarea
+                    .setValue(this.plugin.settings.stackExchangeNote || DEFAULT_SETTINGS.stackExchangeNote)
+                    .onChange(async (value) => {
+                        this.plugin.settings.stackExchangeNote = value;
+                        await this.plugin.saveSettings();
+                    });
+                textarea.inputEl.rows = 10;
+                textarea.inputEl.cols = 25;
+            });
 
-        new Setting(containerEl).setName('Stack Exchange answer template').addTextArea((textarea) => {
-            textarea
-                .setValue(this.plugin.settings.stackExchangeAnswer || DEFAULT_SETTINGS.stackExchangeAnswer)
-                .onChange(async (value) => {
-                    this.plugin.settings.stackExchangeAnswer = value;
-                    await this.plugin.saveSettings();
-                });
-            textarea.inputEl.rows = 10;
-            textarea.inputEl.cols = 25;
-        });
+        new Setting(containerEl)
+            .setName('Stack Exchange answer template')
+            .setDesc(this.createTemplateVariableReferenceDiv())
+            .addTextArea((textarea) => {
+                textarea
+                    .setValue(this.plugin.settings.stackExchangeAnswer || DEFAULT_SETTINGS.stackExchangeAnswer)
+                    .onChange(async (value) => {
+                        this.plugin.settings.stackExchangeAnswer = value;
+                        await this.plugin.saveSettings();
+                    });
+                textarea.inputEl.rows = 10;
+                textarea.inputEl.cols = 25;
+            });
 
         new Setting(containerEl)
             .setName('Download media attachments')
-            .setDesc('If enabled, media attachments are downloaded to the assets folder (only Desktop App feature)')
+            .setDesc(
+                'Media attachments will be downloaded to the assets folder (Desktop App feature only). To dynamically change destination folder you can use variables. Check variables reference to learn more.',
+            )
             .addToggle((toggle) =>
                 toggle
                     .setValue(
@@ -381,14 +513,19 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
                     )
                     .onChange(async (value) => {
                         this.plugin.settings.downloadStackExchangeAssets = value;
-                        stackExchangeMediaAttachmentsInDirSetting.setDisabled(!value);
+                        if (value === false) {
+                            this.plugin.settings.downloadStackExchangeAssetsInDir = false;
+                        }
                         await this.plugin.saveSettings();
+                        this.display();
                     }),
             );
 
-        const stackExchangeMediaAttachmentsInDirSetting = new Setting(containerEl)
+        new Setting(containerEl)
             .setName('Download media attachments to folder')
-            .setDesc('If enabled, the media attachments are stored in their own folder.')
+            .setDesc(
+                'Media attachments will be downloaded to the note assets folder (Desktop App feature only). Overrides assets folder template.',
+            )
             .addToggle((toggle) =>
                 toggle
                     .setValue(
@@ -398,37 +535,64 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
                     )
                     .onChange(async (value) => {
                         this.plugin.settings.downloadStackExchangeAssetsInDir = value;
+                        if (value === true) {
+                            this.plugin.settings.downloadStackExchangeAssets = true;
+                        }
                         await this.plugin.saveSettings();
+                        this.display();
                     }),
             );
 
         containerEl.createEl('h2', { text: 'Mastodon' });
 
-        new Setting(containerEl).setName('Mastodon note template title').addText((text) =>
-            text
-                .setPlaceholder('Defaults to %tootAuthorName%')
-                .setValue(this.plugin.settings.mastodonNoteTitle || DEFAULT_SETTINGS.mastodonNoteTitle)
-                .onChange(async (value) => {
-                    this.plugin.settings.mastodonNoteTitle = value;
-                    await this.plugin.saveSettings();
-                }),
-        );
+        new Setting(containerEl)
+            .setName('Mastodon content type slug')
+            .setDesc(this.createTemplateVariableReferenceDiv())
+            .addText((text) =>
+                text
+                    .setPlaceholder(`Defaults to ${DEFAULT_SETTINGS.mastodonContentTypeSlug}`)
+                    .setValue(
+                        typeof this.plugin.settings.mastodonContentTypeSlug === 'undefined'
+                            ? DEFAULT_SETTINGS.mastodonContentTypeSlug
+                            : this.plugin.settings.mastodonContentTypeSlug,
+                    )
+                    .onChange(async (value) => {
+                        this.plugin.settings.mastodonContentTypeSlug = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
-        new Setting(containerEl).setName('Mastodon note template').addTextArea((textarea) => {
-            textarea
-                .setValue(this.plugin.settings.mastodonNote || DEFAULT_SETTINGS.mastodonNote)
-                .onChange(async (value) => {
-                    this.plugin.settings.mastodonNote = value;
-                    await this.plugin.saveSettings();
-                });
-            textarea.inputEl.rows = 10;
-            textarea.inputEl.cols = 25;
-        });
+        new Setting(containerEl)
+            .setName('Mastodon note template title')
+            .setDesc(this.createTemplateVariableReferenceDiv())
+            .addText((text) =>
+                text
+                    .setPlaceholder('Defaults to %tootAuthorName%')
+                    .setValue(this.plugin.settings.mastodonNoteTitle || DEFAULT_SETTINGS.mastodonNoteTitle)
+                    .onChange(async (value) => {
+                        this.plugin.settings.mastodonNoteTitle = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
+
+        new Setting(containerEl)
+            .setName('Mastodon note template')
+            .setDesc(this.createTemplateVariableReferenceDiv())
+            .addTextArea((textarea) => {
+                textarea
+                    .setValue(this.plugin.settings.mastodonNote || DEFAULT_SETTINGS.mastodonNote)
+                    .onChange(async (value) => {
+                        this.plugin.settings.mastodonNote = value;
+                        await this.plugin.saveSettings();
+                    });
+                textarea.inputEl.rows = 10;
+                textarea.inputEl.cols = 25;
+            });
 
         new Setting(containerEl)
             .setName('Download media attachments')
             .setDesc(
-                'If enabled, media attachments of toot are downloaded to the assets folder (only Desktop App feature)',
+                'Media attachments will be downloaded to the assets folder (Desktop App feature only). To dynamically change destination folder you can use variables. Check variables reference to learn more.',
             )
             .addToggle((toggle) =>
                 toggle
@@ -439,14 +603,19 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
                     )
                     .onChange(async (value) => {
                         this.plugin.settings.downloadMastodonMediaAttachments = value;
-                        mastodonMediaAttachmentsInDirSetting.setDisabled(!value);
+                        if (value === false) {
+                            this.plugin.settings.downloadMastodonMediaAttachmentsInDir = false;
+                        }
                         await this.plugin.saveSettings();
+                        this.display();
                     }),
             );
 
-        const mastodonMediaAttachmentsInDirSetting = new Setting(containerEl)
+        new Setting(containerEl)
             .setName('Download media attachments to folder')
-            .setDesc('If enabled, the media attachments of toot are stored in their own folder.')
+            .setDesc(
+                'Media attachments will be downloaded to the note assets folder (Desktop App feature only). Overrides assets folder template.',
+            )
             .addToggle((toggle) =>
                 toggle
                     .setValue(
@@ -459,7 +628,11 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
                     )
                     .onChange(async (value) => {
                         this.plugin.settings.downloadMastodonMediaAttachmentsInDir = value;
+                        if (value === true) {
+                            this.plugin.settings.downloadMastodonMediaAttachments = true;
+                        }
                         await this.plugin.saveSettings();
+                        this.display();
                     }),
             );
 
@@ -492,26 +665,49 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
 
         containerEl.createEl('h2', { text: 'TikTok' });
 
-        new Setting(containerEl).setName('TikTok note title template').addText((text) =>
-            text
-                .setPlaceholder('TikTok from %authorName% (%date%)')
-                .setValue(this.plugin.settings.tikTokNoteTitle || DEFAULT_SETTINGS.tikTokNoteTitle)
-                .onChange(async (value) => {
-                    this.plugin.settings.tikTokNoteTitle = value;
-                    await this.plugin.saveSettings();
-                }),
-        );
+        new Setting(containerEl)
+            .setName('TikTok content type slug')
+            .setDesc(this.createTemplateVariableReferenceDiv())
+            .addText((text) =>
+                text
+                    .setPlaceholder(`Defaults to ${DEFAULT_SETTINGS.tikTokContentTypeSlug}`)
+                    .setValue(
+                        typeof this.plugin.settings.tikTokContentTypeSlug === 'undefined'
+                            ? DEFAULT_SETTINGS.tikTokContentTypeSlug
+                            : this.plugin.settings.tikTokContentTypeSlug,
+                    )
+                    .onChange(async (value) => {
+                        this.plugin.settings.tikTokContentTypeSlug = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
-        new Setting(containerEl).setName('TikTok note template').addTextArea((textarea) => {
-            textarea
-                .setValue(this.plugin.settings.tikTokNote || DEFAULT_SETTINGS.tikTokNote)
-                .onChange(async (value) => {
-                    this.plugin.settings.tikTokNote = value;
-                    await this.plugin.saveSettings();
-                });
-            textarea.inputEl.rows = 10;
-            textarea.inputEl.cols = 25;
-        });
+        new Setting(containerEl)
+            .setName('TikTok note title template')
+            .setDesc(this.createTemplateVariableReferenceDiv())
+            .addText((text) =>
+                text
+                    .setPlaceholder('TikTok from %authorName% (%date%)')
+                    .setValue(this.plugin.settings.tikTokNoteTitle || DEFAULT_SETTINGS.tikTokNoteTitle)
+                    .onChange(async (value) => {
+                        this.plugin.settings.tikTokNoteTitle = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
+
+        new Setting(containerEl)
+            .setName('TikTok note template')
+            .setDesc(this.createTemplateVariableReferenceDiv())
+            .addTextArea((textarea) => {
+                textarea
+                    .setValue(this.plugin.settings.tikTokNote || DEFAULT_SETTINGS.tikTokNote)
+                    .onChange(async (value) => {
+                        this.plugin.settings.tikTokNote = value;
+                        await this.plugin.saveSettings();
+                    });
+                textarea.inputEl.rows = 10;
+                textarea.inputEl.cols = 25;
+            });
 
         new Setting(containerEl).setName('TikTok embed player width').addText((text) =>
             text
@@ -535,30 +731,57 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
 
         containerEl.createEl('h2', { text: 'Readable Article' });
 
-        new Setting(containerEl).setName('Readable article note template title').addText((text) =>
-            text
-                .setPlaceholder('Defaults to %title%')
-                .setValue(this.plugin.settings.parseableArticleNoteTitle || DEFAULT_SETTINGS.parseableArticleNoteTitle)
-                .onChange(async (value) => {
-                    this.plugin.settings.parseableArticleNoteTitle = value;
-                    await this.plugin.saveSettings();
-                }),
-        );
+        new Setting(containerEl)
+            .setName('Readable content type slug')
+            .setDesc(this.createTemplateVariableReferenceDiv())
+            .addText((text) =>
+                text
+                    .setPlaceholder(`Defaults to ${DEFAULT_SETTINGS.parseableArticleContentType}`)
+                    .setValue(
+                        typeof this.plugin.settings.parseableArticleContentType === 'undefined'
+                            ? DEFAULT_SETTINGS.parseableArticleContentType
+                            : this.plugin.settings.parseableArticleContentType,
+                    )
+                    .onChange(async (value) => {
+                        this.plugin.settings.parseableArticleContentType = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
-        new Setting(containerEl).setName('Readable article note template').addTextArea((textarea) => {
-            textarea
-                .setValue(this.plugin.settings.parsableArticleNote || DEFAULT_SETTINGS.parsableArticleNote)
-                .onChange(async (value) => {
-                    this.plugin.settings.parsableArticleNote = value;
-                    await this.plugin.saveSettings();
-                });
-            textarea.inputEl.rows = 10;
-            textarea.inputEl.cols = 25;
-        });
+        new Setting(containerEl)
+            .setName('Readable article note template title')
+            .setDesc(this.createTemplateVariableReferenceDiv())
+            .addText((text) =>
+                text
+                    .setPlaceholder('Defaults to %title%')
+                    .setValue(
+                        this.plugin.settings.parseableArticleNoteTitle || DEFAULT_SETTINGS.parseableArticleNoteTitle,
+                    )
+                    .onChange(async (value) => {
+                        this.plugin.settings.parseableArticleNoteTitle = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
+
+        new Setting(containerEl)
+            .setName('Readable article note template')
+            .setDesc(this.createTemplateVariableReferenceDiv())
+            .addTextArea((textarea) => {
+                textarea
+                    .setValue(this.plugin.settings.parsableArticleNote || DEFAULT_SETTINGS.parsableArticleNote)
+                    .onChange(async (value) => {
+                        this.plugin.settings.parsableArticleNote = value;
+                        await this.plugin.saveSettings();
+                    });
+                textarea.inputEl.rows = 10;
+                textarea.inputEl.cols = 25;
+            });
 
         new Setting(containerEl)
             .setName('Download images')
-            .setDesc('If enabled, images in article are downloaded to the assets folder (only Desktop App feature)')
+            .setDesc(
+                'Images from article will be downloaded to the assets folder (Desktop App feature only). To dynamically change destination folder you can use variables. Check variables reference to learn more.',
+            )
             .addToggle((toggle) =>
                 toggle
                     .setValue(
@@ -568,14 +791,19 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
                     )
                     .onChange(async (value) => {
                         this.plugin.settings.downloadImages = value;
-                        imagesInArticleDirSettings.setDisabled(!value);
+                        if (value === false) {
+                            this.plugin.settings.downloadImagesInArticleDir = false;
+                        }
                         await this.plugin.saveSettings();
+                        this.display();
                     }),
             );
 
-        const imagesInArticleDirSettings = new Setting(containerEl)
+        new Setting(containerEl)
             .setName('Download images to note folder')
-            .setDesc('If enabled, the images in article are stored in their own folder.')
+            .setDesc(
+                'Images from article will be downloaded to the note assets folder (Desktop App feature only). Overrides assets folder template.',
+            )
             .addToggle((toggle) =>
                 toggle
                     .setValue(
@@ -585,56 +813,117 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
                     )
                     .onChange(async (value) => {
                         this.plugin.settings.downloadImagesInArticleDir = value;
+                        if (value === true) {
+                            this.plugin.settings.downloadImages = true;
+                        }
                         await this.plugin.saveSettings();
+                        this.display();
                     }),
             );
 
         containerEl.createEl('h2', { text: 'Nonreadable Article' });
 
-        new Setting(containerEl).setName('Nonreadable article note template title').addText((text) =>
-            text
-                .setPlaceholder("Defaults to 'Article %date%'")
-                .setValue(
-                    this.plugin.settings.notParseableArticleNoteTitle || DEFAULT_SETTINGS.notParseableArticleNoteTitle,
-                )
-                .onChange(async (value) => {
-                    this.plugin.settings.notParseableArticleNoteTitle = value;
-                    await this.plugin.saveSettings();
-                }),
-        );
+        new Setting(containerEl)
+            .setName('Nonreadable content type slug')
+            .setDesc(this.createTemplateVariableReferenceDiv())
+            .addText((text) =>
+                text
+                    .setPlaceholder(`Defaults to ${DEFAULT_SETTINGS.notParseableArticleContentType}`)
+                    .setValue(
+                        typeof this.plugin.settings.notParseableArticleContentType === 'undefined'
+                            ? DEFAULT_SETTINGS.notParseableArticleContentType
+                            : this.plugin.settings.notParseableArticleContentType,
+                    )
+                    .onChange(async (value) => {
+                        this.plugin.settings.notParseableArticleContentType = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
-        new Setting(containerEl).setName('Nonreadable article note template').addTextArea((textarea) => {
-            textarea
-                .setValue(this.plugin.settings.notParsableArticleNote || DEFAULT_SETTINGS.notParsableArticleNote)
-                .onChange(async (value) => {
-                    this.plugin.settings.notParsableArticleNote = value;
-                    await this.plugin.saveSettings();
-                });
-            textarea.inputEl.rows = 10;
-            textarea.inputEl.cols = 25;
-        });
+        new Setting(containerEl)
+            .setName('Nonreadable article note template title')
+            .setDesc(this.createTemplateVariableReferenceDiv())
+            .addText((text) =>
+                text
+                    .setPlaceholder("Defaults to 'Article %date%'")
+                    .setValue(
+                        this.plugin.settings.notParseableArticleNoteTitle ||
+                        DEFAULT_SETTINGS.notParseableArticleNoteTitle,
+                    )
+                    .onChange(async (value) => {
+                        this.plugin.settings.notParseableArticleNoteTitle = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
+
+        new Setting(containerEl)
+            .setName('Nonreadable article note template')
+            .setDesc(this.createTemplateVariableReferenceDiv())
+            .addTextArea((textarea) => {
+                textarea
+                    .setValue(this.plugin.settings.notParsableArticleNote || DEFAULT_SETTINGS.notParsableArticleNote)
+                    .onChange(async (value) => {
+                        this.plugin.settings.notParsableArticleNote = value;
+                        await this.plugin.saveSettings();
+                    });
+                textarea.inputEl.rows = 10;
+                textarea.inputEl.cols = 25;
+            });
 
         containerEl.createEl('h2', { text: 'Text Snippet' });
 
-        new Setting(containerEl).setName('Text snippet note template title').addText((text) =>
-            text
-                .setPlaceholder("Defaults to 'Note %date%'")
-                .setValue(this.plugin.settings.textSnippetNoteTitle || DEFAULT_SETTINGS.textSnippetNoteTitle)
-                .onChange(async (value) => {
-                    this.plugin.settings.textSnippetNoteTitle = value;
-                    await this.plugin.saveSettings();
-                }),
-        );
+        new Setting(containerEl)
+            .setName('Text Snippet content type slug')
+            .setDesc(this.createTemplateVariableReferenceDiv())
+            .addText((text) =>
+                text
+                    .setPlaceholder(`Defaults to ${DEFAULT_SETTINGS.textSnippetContentType}`)
+                    .setValue(
+                        typeof this.plugin.settings.textSnippetContentType === 'undefined'
+                            ? DEFAULT_SETTINGS.textSnippetContentType
+                            : this.plugin.settings.textSnippetContentType,
+                    )
+                    .onChange(async (value) => {
+                        this.plugin.settings.textSnippetContentType = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
 
-        new Setting(containerEl).setName('Text snippet note template').addTextArea((textarea) => {
-            textarea
-                .setValue(this.plugin.settings.textSnippetNote || DEFAULT_SETTINGS.textSnippetNote)
-                .onChange(async (value) => {
-                    this.plugin.settings.textSnippetNote = value;
-                    await this.plugin.saveSettings();
-                });
-            textarea.inputEl.rows = 10;
-            textarea.inputEl.cols = 25;
-        });
+        new Setting(containerEl)
+            .setName('Text snippet note template title')
+            .setDesc(this.createTemplateVariableReferenceDiv())
+            .addText((text) =>
+                text
+                    .setPlaceholder("Defaults to 'Note %date%'")
+                    .setValue(this.plugin.settings.textSnippetNoteTitle || DEFAULT_SETTINGS.textSnippetNoteTitle)
+                    .onChange(async (value) => {
+                        this.plugin.settings.textSnippetNoteTitle = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
+
+        new Setting(containerEl)
+            .setName('Text snippet note template')
+            .setDesc(this.createTemplateVariableReferenceDiv())
+            .addTextArea((textarea) => {
+                textarea
+                    .setValue(this.plugin.settings.textSnippetNote || DEFAULT_SETTINGS.textSnippetNote)
+                    .onChange(async (value) => {
+                        this.plugin.settings.textSnippetNote = value;
+                        await this.plugin.saveSettings();
+                    });
+                textarea.inputEl.rows = 10;
+                textarea.inputEl.cols = 25;
+            });
+    }
+
+    private createHTMLDiv(html: string): DocumentFragment {
+        return createFragment((documentFragment) => (documentFragment.createDiv().innerHTML = html));
+    }
+
+    private createTemplateVariableReferenceDiv(prepend: string = ''): DocumentFragment {
+        return this.createHTMLDiv(
+            `<p>${prepend} See the <a href="https://github.com/DominikPieper/obsidian-ReadItLater?tab=readme-ov-file#template-engine">template variables reference</a></p>`,
+        );
     }
 }

--- a/src/views/settings-tab.ts
+++ b/src/views/settings-tab.ts
@@ -19,9 +19,9 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
         containerEl.createEl('h2', { text: 'General' });
 
         new Setting(containerEl)
-            .setName('Inbox dir')
+            .setName('Inbox directory')
             .setDesc(
-                'Enter valid folder name. For nested folders use this format: Folder A/Folder B. If no folder is entered, new note will be created in vault root.',
+                'Enter valid directory name. For nested directory use this format: Directory A/Directory B. If no directory is entered, new note will be created in vault root.',
             )
             .addText((text) =>
                 text
@@ -38,9 +38,9 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
             );
 
         new Setting(containerEl)
-            .setName('Assets dir')
+            .setName('Assets directory')
             .setDesc(
-                'Enter valid folder name. For nested folders use this format: Folder A/Folder B. If no folder is entered, new note will be created in vault root.',
+                'Enter valid directory name. For nested directory use this format: Directory A/Directory B. If no directory is entered, new note will be created in Vault root.',
             )
             .addText((text) =>
                 text
@@ -502,7 +502,7 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
         new Setting(containerEl)
             .setName('Download media attachments')
             .setDesc(
-                'Media attachments will be downloaded to the assets folder (Desktop App feature only). To dynamically change destination folder you can use variables. Check variables reference to learn more.',
+                'Media attachments will be downloaded to the assets directory (Desktop App feature only). To dynamically change destination directory you can use variables. Check variables reference to learn more.',
             )
             .addToggle((toggle) =>
                 toggle
@@ -522,9 +522,9 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
             );
 
         new Setting(containerEl)
-            .setName('Download media attachments to folder')
+            .setName('Download media attachments to note directory')
             .setDesc(
-                'Media attachments will be downloaded to the note assets folder (Desktop App feature only). Overrides assets folder template.',
+                'Media attachments will be downloaded to the dedicated note assets directory (Desktop App feature only). Overrides assets directory template.',
             )
             .addToggle((toggle) =>
                 toggle
@@ -592,7 +592,7 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
         new Setting(containerEl)
             .setName('Download media attachments')
             .setDesc(
-                'Media attachments will be downloaded to the assets folder (Desktop App feature only). To dynamically change destination folder you can use variables. Check variables reference to learn more.',
+                'Media attachments will be downloaded to the assets directory (Desktop App feature only). To dynamically change destination directory you can use variables. Check variables reference to learn more.',
             )
             .addToggle((toggle) =>
                 toggle
@@ -612,9 +612,9 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
             );
 
         new Setting(containerEl)
-            .setName('Download media attachments to folder')
+            .setName('Download media attachments to note directory')
             .setDesc(
-                'Media attachments will be downloaded to the note assets folder (Desktop App feature only). Overrides assets folder template.',
+                'Media attachments will be downloaded to the dedicated note assets directory (Desktop App feature only). Overrides assets directory template.',
             )
             .addToggle((toggle) =>
                 toggle
@@ -780,7 +780,7 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
         new Setting(containerEl)
             .setName('Download images')
             .setDesc(
-                'Images from article will be downloaded to the assets folder (Desktop App feature only). To dynamically change destination folder you can use variables. Check variables reference to learn more.',
+                'Images from article will be downloaded to the assets directory (Desktop App feature only). To dynamically change destination directory you can use variables. Check variables reference to learn more.',
             )
             .addToggle((toggle) =>
                 toggle
@@ -800,9 +800,9 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
             );
 
         new Setting(containerEl)
-            .setName('Download images to note folder')
+            .setName('Download images to note directory')
             .setDesc(
-                'Images from article will be downloaded to the note assets folder (Desktop App feature only). Overrides assets folder template.',
+                'Images from article will be downloaded to the dedicated note assets directory (Desktop App feature only). Overrides assets directory template.',
             )
             .addToggle((toggle) =>
                 toggle

--- a/src/views/settings-tab.ts
+++ b/src/views/settings-tab.ts
@@ -848,7 +848,7 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
                     .setPlaceholder("Defaults to 'Article %date%'")
                     .setValue(
                         this.plugin.settings.notParseableArticleNoteTitle ||
-                        DEFAULT_SETTINGS.notParseableArticleNoteTitle,
+                            DEFAULT_SETTINGS.notParseableArticleNoteTitle,
                     )
                     .onChange(async (value) => {
                         this.plugin.settings.notParseableArticleNoteTitle = value;


### PR DESCRIPTION
# Description

Adds ability to use template variables in inbox and assets directory settings enabling more dynamic content creation.

## Motivation and Context

User requested feature in #133 

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content)

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `npm run lint`.
- [x] My change requires an update of README.md
- [x] I have updated the README.md
