### PR TITLE
fix: wikipedia parser regex support for m.wikipedia.org

### DIFF
--- a/src/parsers/WikipediaParser.ts
+++ b/src/parsers/WikipediaParser.ts
@@ -2,7 +2,7 @@ import { Note } from './Note';
 import WebsiteParser from './WebsiteParser';
 
 export default class WikipediaParser extends WebsiteParser {
-    private PATTERN = /^(?:https?:\/\/)?(?:[a-z]{2,3}(?:-[a-z]{2,3})?)\.wikipedia\.org\/wiki\/([^/]+)$/i;
+    private PATTERN = /^(?:https?:\/\/)?(?:[a-z]{2,3}(?:-[a-z]{2,3})?)(?:\.m)?\.wikipedia\.org\/wiki\/([^\/]+)$/i;
 
     test(url: string): boolean {
         return this.isValidUrl(url) && this.PATTERN.test(url);


### PR DESCRIPTION
# Description

Fix WikipediaParser regex to support also m.wikipedia.org domain.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content)

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `npm run lint`.
- [ ] My change requires an update of README.md
- [ ] I have updated the README.md
