### PR TITLE
feat: add youtube chapters template variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Parsing of HTML DOM has its limitations thus additional data can be fetched only
 | videoPublishDate          | Video plublish date formatted in content format from plugin settings |
 | videoTags                 | Formatted list of tags delimited by space                            |
 | videoViewsCount           | Video views count                                                    |
+| videoChapters             | List of video chapters with linked timestamps                        |
 
 ### Youtube Channel
 

--- a/src/ReadtItLaterApi.ts
+++ b/src/ReadtItLaterApi.ts
@@ -5,22 +5,22 @@ export class ReadItLaterApi {
     constructor(private noteService: NoteService) {}
 
     /**
-    * Create single note from provided input.
-    */
+     * Create single note from provided input.
+     */
     public async processContent(content: string): Promise<void> {
         this.noteService.createNote(content);
     }
 
     /**
-    * Create multiple notes from provided input delimited by delimiter defined in plugin settings.
-    */
+     * Create multiple notes from provided input delimited by delimiter defined in plugin settings.
+     */
     public async processContentBatch(contentBatch: string): Promise<void> {
         this.noteService.createNotesFromBatch(contentBatch);
     }
 
     /**
-    * Insert processed content from input at current position in editor.
-    */
+     * Insert processed content from input at current position in editor.
+     */
     public async insertContentAtEditorCursorPosition(content: string, editor: Editor): Promise<void> {
         this.noteService.insertContentAtEditorCursorPosition(content, editor);
     }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -86,7 +86,7 @@ export const DEFAULT_SETTINGS: ReadItLaterSettings = {
     youtubeUsePrivacyEnhancedEmbed: true,
     vimeoContentTypeSlug: 'vimeo',
     vimeoNoteTitle: 'Vimeo - {{ title }}',
-    vimeoNote: '[[ReadItLater]] [[Vimeo]]\n\n# [{{ videoTitle }}]({{ videoURL }})\n\n{{ videoPlayer }}',
+    vimeoNote: '[[ReadItLater]] [[Vimeo]]\n\n# [{{ videoTitle }}]({{ videoURL }})\n\n{{ videoPlayer }}\n\n{{ videoChapters }}',
     vimeoEmbedWidth: '560',
     vimeoEmbedHeight: '315',
     bilibiliContentTypeSlug: 'bilibili',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Add new template variable for YouTube content type with list of chapters with timestamped links.

## Motivation and Context

User requested feature in #131 

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content)

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `npm run lint`.
- [x] My change requires an update of README.md
- [x] I have updated the README.md
