### PR TITLE
fix: substack images

### DIFF
--- a/src/parsers/WebsiteParser.ts
+++ b/src/parsers/WebsiteParser.ts
@@ -141,6 +141,17 @@ class WebsiteParser extends Parser {
             }
         });
 
+        //fix for substack images
+        document.body.querySelectorAll('.captioned-image-container figure')?.forEach((figure) => {
+            const imgEl = figure.querySelector('img');
+            if (!imgEl) {
+                return;
+            }
+
+            figure.querySelector('.image-link').remove();
+            figure.prepend(imgEl);
+        });
+
         return document;
     }
 


### PR DESCRIPTION


# Description

Provides fix for substack images. Specifically removes surrounding `<a>` tag that caused wrong markdown formatting.

## How has this been tested?

Saving multiple Substack posts:
- https://www.pdole.ga/p/the-software-engineers-career-beyond
- https://www.pdole.ga/p/building-engineering-progression-7ca

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content)

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `npm run lint`.
- [ ] My change requires an update of README.md
- [ ] I have updated the README.md
