### PR TITLE
hotfix: preserve emojis defined in filename template

### DIFF
--- a/src/helpers/fileutils.ts
+++ b/src/helpers/fileutils.ts
@@ -27,7 +27,11 @@ export function getBaseUrl(url: string, origin: string): string {
     return baseURL.href;
 }
 
-export function normalizeFilename(fileName: string): string {
+export function normalizeFilename(fileName: string, preserveUnicode: boolean = true): string {
+    if (preserveUnicode) {
+        return fileName.replace(/[:#/\\|?*<>"]/g, '');
+    }
+
     return fileName.replace(
         /[:#/\\()|?*<>"[\u{1F300}-\u{1F9FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}\u{1F000}-\u{1F02F}\u{1F0A0}-\u{1F0FF}\u{1F100}-\u{1F64F}\u{1F680}-\u{1F6FF}]/gu,
         '',

--- a/src/parsers/BlueskyParser.ts
+++ b/src/parsers/BlueskyParser.ts
@@ -138,7 +138,7 @@ export class BlueskyParser extends Parser {
         const fileName = this.templateEngine.render(this.plugin.settings.blueskyNoteTitle, {
             date: this.getFormattedDateForFilename(createdAt),
             authorHandle: post.author.handle,
-            authorName: post.author.displayName,
+            authorName: normalizeFilename(post.author.displayName, false),
         });
 
         if (this.plugin.settings.downloadBlueskyEmbeds) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Provides fix for striping out emojis from user defined filename templates.

## Motivation and Context

Fix #219 

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content)

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `npm run lint`.
- [ ] My change requires an update of README.md
- [ ] I have updated the README.md
