### PR TITLE
feat: youtube chapter template

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,13 @@ If enabled, images will be downloaded to folder (default is `ReadItLater Inbox/a
 | videoPublishDate          | Video plublish date formatted in content format from plugin settings |
 | videoViewsCount           | Video views count                                                    |
 
+| Chapter template variable | Description                   |
+| ------------------------- | ----------------------------- |
+| chapterTitle              | Chapter title                 |
+| chapterTimestamp          | Chapter start time in mm:ss   |
+| chapterSeconds            | Chapter start time in seconds |
+| chapterUrl                | Url to chapter start          |
+
 Parsing of HTML DOM has its limitations thus additional data can be fetched only from [Google API](https://developers.google.com/youtube/v3/getting-started). Retrieved API key can be set in plugin settings and then plugin will use the Google API for fetching data.
 
 | Content template variable | Description                                                          |

--- a/src/parsers/YoutubeParser.ts
+++ b/src/parsers/YoutubeParser.ts
@@ -245,8 +245,13 @@ class YoutubeParser extends Parser {
     private formatVideoChapters(videoId: string, chapters: YoutubeVideoChapter[]): string {
         return chapters
             .map((chapter) => {
-                return `- [${chapter.timestamp}](https://www.youtube.com/watch?v=${videoId}&t=${chapter.seconds}) ${chapter.title}`;
-            })
+                return this.templateEngine.render(this.plugin.settings.youtubeChapter, {
+                    chapterTimestamp: chapter.timestamp,
+                    chapterTitle: chapter.title,
+                    chapterSeconds: chapter.seconds,
+                    chapterUrl: `https://www.youtube.com/watch?v=${videoId}&t=${chapter.seconds}`,
+                });
+            }, this)
             .join('\n');
     }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -92,7 +92,8 @@ export const DEFAULT_SETTINGS: ReadItLaterSettings = {
     openNewNoteInNewTab: false,
     youtubeContentTypeSlug: 'youtube',
     youtubeNoteTitle: 'Youtube - {{ title }}',
-    youtubeNote: '[[ReadItLater]] [[Youtube]]\n\n# [{{ videoTitle }}]({{ videoURL }})\n\n{{ videoPlayer }}\n\n{{ videoChapters }}',
+    youtubeNote:
+        '[[ReadItLater]] [[Youtube]]\n\n# [{{ videoTitle }}]({{ videoURL }})\n\n{{ videoPlayer }}\n\n{{ videoChapters }}',
     youtubeChapter: '- [{{ chapterTimestamp }}]({{ chapterUrl }}) {{ chapterTitle }}',
     youtubeEmbedWidth: '560',
     youtubeEmbedHeight: '315',

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -14,6 +14,7 @@ export interface ReadItLaterSettings {
     youtubeContentTypeSlug: string;
     youtubeNoteTitle: string;
     youtubeNote: string;
+    youtubeChapter: string;
     youtubeEmbedWidth: string;
     youtubeEmbedHeight: string;
     youtubeUsePrivacyEnhancedEmbed: boolean;
@@ -91,7 +92,8 @@ export const DEFAULT_SETTINGS: ReadItLaterSettings = {
     openNewNoteInNewTab: false,
     youtubeContentTypeSlug: 'youtube',
     youtubeNoteTitle: 'Youtube - {{ title }}',
-    youtubeNote: '[[ReadItLater]] [[Youtube]]\n\n# [{{ videoTitle }}]({{ videoURL }})\n\n{{ videoPlayer }}',
+    youtubeNote: '[[ReadItLater]] [[Youtube]]\n\n# [{{ videoTitle }}]({{ videoURL }})\n\n{{ videoPlayer }}\n\n{{ videoChapters }}',
+    youtubeChapter: '- [{{ chapterTimestamp }}]({{ chapterUrl }}) {{ chapterTitle }}',
     youtubeEmbedWidth: '560',
     youtubeEmbedHeight: '315',
     youtubeUsePrivacyEnhancedEmbed: true,

--- a/src/views/settings-tab.ts
+++ b/src/views/settings-tab.ts
@@ -359,6 +359,20 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
                 textarea.inputEl.cols = 25;
             });
 
+        new Setting(detailsEl)
+            .setName('Youtube chapter template')
+            .setDesc(this.createTemplateVariableReferenceDiv())
+            .addTextArea((textarea) => {
+                textarea
+                    .setValue(this.plugin.settings.youtubeChapter || DEFAULT_SETTINGS.youtubeChapter)
+                    .onChange(async (value) => {
+                        this.plugin.settings.youtubeChapter = value;
+                        await this.plugin.saveSettings();
+                    });
+                textarea.inputEl.rows = 10;
+                textarea.inputEl.cols = 25;
+            });
+
         new Setting(detailsEl).setName('Youtube embed player width').addText((text) =>
             text
                 .setPlaceholder(DEFAULT_SETTINGS.youtubeEmbedWidth)


### PR DESCRIPTION
* added template for youtube chapters
* added %videoChapters% to youtube default note template

<!--- Provide a general summary of your changes in the Title above -->

# Description

Implemented a setting so that the chapters can formatted as well

## Motivation and Context

With this change the timestamps can be used in a customizable way. For me they now can work together with the [Timestamp Notes Plugin](https://github.com/juliang22/ObsidianTimestampNotes)

## How has this been tested?

- Trigger a youtube video
- Changed the settings
- Delete the previously generated note
- Trigger it again

System: MacOS (M1)
This should not affect other parts of the addon



## Types of changes

Changes visible to users:

- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [x] **Documentation** (prefix: `docs` - improvements to any documentation content)

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `npm run lint`.
- [x] My change requires an update of README.md
- [x] I have updated the README.md
